### PR TITLE
Improve locators

### DIFF
--- a/tests/pages/basePage.ts
+++ b/tests/pages/basePage.ts
@@ -21,7 +21,7 @@ export default class BasePage {
     this.page = page;
     this.globalMessage = page.locator('.global.message');
     this.pageHeader = page.locator('header.page-header');
-    this.banner = page.locator('.panel.wrapper');
+    this.banner = this.pageHeader.locator('.panel.wrapper');
     this.bannerLink = this.banner.locator('li a');
     this.logoLink = page.locator('a.logo');
     this.searchInput = page.locator('input#search');

--- a/tests/pages/basePage.ts
+++ b/tests/pages/basePage.ts
@@ -12,6 +12,7 @@ export default class BasePage {
   readonly topNav: Locator;
   readonly topNavLink: Locator;
   readonly topNavLvl0Link: Locator;
+  readonly adsWidget: Locator
   readonly pageFooter: Locator;
   readonly pageFooterLink: Locator;
   readonly copyrightFooter: Locator;
@@ -28,6 +29,7 @@ export default class BasePage {
     this.topNav = page.locator('.nav-sections');
     this.topNavLink = this.topNav.getByRole('menuitem');
     this.topNavLvl0Link = this.topNav.locator('li.level0').getByRole('menuitem');
+    this.adsWidget = page.locator('.widget').filter({has: page.locator('ins.adsbygoogle')});
     this.pageFooter = page.locator('footer.page-footer');
     this.pageFooterLink = this.pageFooter.locator('li a');
     this.copyrightFooter = page.locator('.copyright');

--- a/tests/pages/homePage.ts
+++ b/tests/pages/homePage.ts
@@ -4,7 +4,6 @@ import BasePage from './basePage';
 export class HomePage extends BasePage {
   url: string = '/';
   readonly mainContent: Locator;
-  readonly adsWidget: Locator;
   readonly promoBlock: Locator;
   readonly contentHeading: Locator;
   readonly productsGrid: Locator;
@@ -13,7 +12,6 @@ export class HomePage extends BasePage {
   constructor(page: Page) {
     super(page);
     this.mainContent = page.locator('#maincontent');
-    this.adsWidget = page.locator('.widget').nth(0);
     this.promoBlock = page.locator('.block-promo');
     this.contentHeading = page.locator('.content-heading');
     this.productsGrid = page.locator('.products-grid');

--- a/tests/pages/signInPage.ts
+++ b/tests/pages/signInPage.ts
@@ -6,7 +6,6 @@ export default class SignInPage extends BasePage {
   readonly pageTitle: Locator;
   readonly errorMessage: Locator;
   readonly mainContentArea: Locator;
-  readonly adsWidget: Locator;
   readonly existingCustomerBlock: Locator;
   readonly existingCustomerHeading: Locator;
   readonly loginForm: Locator;
@@ -29,7 +28,6 @@ export default class SignInPage extends BasePage {
     this.pageTitle = page.locator('h1.page-title');
     this.errorMessage = page.getByRole('alert').first();
     this.mainContentArea = page.locator('.main');
-    this.adsWidget = page.locator('.widget').nth(0);
     this.existingCustomerBlock = this.mainContentArea.locator('.block-customer-login');
     this.existingCustomerHeading = this.existingCustomerBlock.locator('.block-title');
     this.loginForm = this.existingCustomerBlock.locator('#login-form');

--- a/tests/pages/signInPage.ts
+++ b/tests/pages/signInPage.ts
@@ -3,9 +3,9 @@ import BasePage from './basePage';
 
 export default class SignInPage extends BasePage {
   url = '/customer/account/login/';
+  readonly mainContentArea: Locator;
   readonly pageTitle: Locator;
   readonly errorMessage: Locator;
-  readonly mainContentArea: Locator;
   readonly existingCustomerBlock: Locator;
   readonly existingCustomerHeading: Locator;
   readonly loginForm: Locator;
@@ -25,9 +25,9 @@ export default class SignInPage extends BasePage {
 
   constructor(page: Page) {
     super(page);
-    this.pageTitle = page.locator('h1.page-title');
-    this.errorMessage = page.getByRole('alert').first();
-    this.mainContentArea = page.locator('.main');
+    this.mainContentArea = page.locator('#maincontent');
+    this.pageTitle = this.mainContentArea.getByRole('heading', {level: 1});
+    this.errorMessage = this.mainContentArea.getByRole('alert').first();
     this.existingCustomerBlock = this.mainContentArea.locator('.block-customer-login');
     this.existingCustomerHeading = this.existingCustomerBlock.locator('.block-title');
     this.loginForm = this.existingCustomerBlock.locator('#login-form');


### PR DESCRIPTION
Playwright advocates using user-facing attributes for locators such as element names rather than things like classes which could change as the web application is developed. Ideally I'd use specific test attributes (e.g. `data-testid`) on elements but as I can't edit the source code of the application under test that's not an option here. The easiest locators to use are often classes and IDs (where available) and while this risks tests breaking if the application changes isn't that also part of the point of the tests? To my mind, using user-facing attributes such as names in POM locators is an implicit assertion on the element whereas I favour an explicit assertion i.e. a test to verify the element located by class, ID etc has the right display name in the UI. However, I have used Playwright's guidance to modify several locators within the existing POMs