### PR TITLE
Soft assertions

### DIFF
--- a/tests/specs/basePage.spec.ts
+++ b/tests/specs/basePage.spec.ts
@@ -16,60 +16,60 @@ test.describe('Base page tests', () => {
     // The tests could be combined but I have split them here to make them easier to read and maintain
 
     test('Common page elements displayed', async () => {
-      await expect(basePage.globalMessage).toBeVisible();
-      await expect(basePage.pageHeader).toBeVisible();
-      await expect(basePage.topNav).toBeVisible();
-      await expect(basePage.pageFooter).toBeVisible();
-      await expect(basePage.copyrightFooter).toBeVisible();
+      await expect.soft(basePage.globalMessage).toBeVisible();
+      await expect.soft(basePage.pageHeader).toBeVisible();
+      await expect.soft(basePage.topNav).toBeVisible();
+      await expect.soft(basePage.pageFooter).toBeVisible();
+      await expect.soft(basePage.copyrightFooter).toBeVisible();
     });
 
     test('Element styling', async () => {
-      await expect(basePage.globalMessage).toHaveCSS('background-color', Colors.Red);
-      await expect(basePage.globalMessage).toHaveCSS('color', Colors.White);
-      await expect(basePage.globalMessage).toHaveCSS('font-size', GlobalMessageStyle.FontSize);
-      await expect(basePage.globalMessage).toHaveCSS('font-weight', GlobalMessageStyle.FontWeight);
-      await expect(basePage.banner).toHaveCSS('background-color', Colors.Grey);
-      await expect(basePage.banner).toHaveCSS('color', Colors.White);
-      await expect(basePage.topNav).toHaveCSS('background-color', Colors.LightGrey);
-      await expect(basePage.topNav).toHaveCSS('color', Colors.DarkGrey);
-      await expect(basePage.pageFooter).toHaveCSS('background-color', Colors.LighterGrey);
-      await expect(basePage.pageFooter).toHaveCSS('color', Colors.DarkGrey);
-      await expect(basePage.copyrightFooter).toHaveCSS('background-color', Colors.Grey);
-      await expect(basePage.copyrightFooter).toHaveCSS('color', Colors.White);
+      await expect.soft(basePage.globalMessage).toHaveCSS('background-color', Colors.Red);
+      await expect.soft(basePage.globalMessage).toHaveCSS('color', Colors.White);
+      await expect.soft(basePage.globalMessage).toHaveCSS('font-size', GlobalMessageStyle.FontSize);
+      await expect.soft(basePage.globalMessage).toHaveCSS('font-weight', GlobalMessageStyle.FontWeight);
+      await expect.soft(basePage.banner).toHaveCSS('background-color', Colors.Grey);
+      await expect.soft(basePage.banner).toHaveCSS('color', Colors.White);
+      await expect.soft(basePage.topNav).toHaveCSS('background-color', Colors.LightGrey);
+      await expect.soft(basePage.topNav).toHaveCSS('color', Colors.DarkGrey);
+      await expect.soft(basePage.pageFooter).toHaveCSS('background-color', Colors.LighterGrey);
+      await expect.soft(basePage.pageFooter).toHaveCSS('color', Colors.DarkGrey);
+      await expect.soft(basePage.copyrightFooter).toHaveCSS('background-color', Colors.Grey);
+      await expect.soft(basePage.copyrightFooter).toHaveCSS('color', Colors.White);
     });
 
     test('Text content of page elements', async () => {
-      await expect(basePage.globalMessage).toHaveText(ExpectedText.GlobalMessage);
-      await expect(basePage.banner).toHaveText(ExpectedText.Banner);
-      await expect(basePage.searchInput).toBeEmpty();
-      await expect(basePage.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
+      await expect.soft(basePage.globalMessage).toHaveText(ExpectedText.GlobalMessage);
+      await expect.soft(basePage.banner).toHaveText(ExpectedText.Banner);
+      await expect.soft(basePage.searchInput).toBeEmpty();
+      await expect.soft(basePage.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
       const topNavLinks = basePage.topNavLvl0Link;
       for (let i = 0; i < (await topNavLinks.count()); i++) {
-        await expect(topNavLinks.nth(i)).toHaveText(ExpectedText.TopNav[i]);
+        await expect.soft(topNavLinks.nth(i)).toHaveText(ExpectedText.TopNav[i]);
       }
       const footerLinks = basePage.pageFooterLink;
       for (let i = 0; i < (await footerLinks.count()); i++) {
-        await expect(footerLinks.nth(i)).toHaveText(ExpectedText.FooterLinks[i]);
+        await expect.soft(footerLinks.nth(i)).toHaveText(ExpectedText.FooterLinks[i]);
       }
-      await expect(basePage.copyrightFooter).toHaveText(ExpectedText.Copyright);
+      await expect.soft(basePage.copyrightFooter).toHaveText(ExpectedText.Copyright);
     });
   });
 
   test.describe('Link tests', () => {
     test('Banner links', async ({ baseURL }) => {
-      await expect(basePage.bannerLink.first()).toHaveAttribute('href', new RegExp(`${baseURL}${Links.SignIn}`));
-      await expect(basePage.bannerLink.nth(1)).toHaveAttribute(
+      await expect.soft(basePage.bannerLink.first()).toHaveAttribute('href', new RegExp(`${baseURL}${Links.SignIn}`));
+      await expect.soft(basePage.bannerLink.nth(1)).toHaveAttribute(
         'href',
         new RegExp(`${baseURL}${Links.CreateAnAccount}`),
       );
     });
 
     test('Logo link', async ({ baseURL }) => {
-      await expect(basePage.logoLink).toHaveAttribute('href', `${baseURL}${Links.Logo}`);
+      await expect.soft(basePage.logoLink).toHaveAttribute('href', `${baseURL}${Links.Logo}`);
     });
 
     test('Shopping cart link', async ({ baseURL }) => {
-      await expect(basePage.cartLink).toHaveAttribute('href', `${baseURL}${Links.Cart}`);
+      await expect.soft(basePage.cartLink).toHaveAttribute('href', `${baseURL}${Links.Cart}`);
     });
 
     test('TopNav links', async ({ baseURL }) => {
@@ -77,7 +77,7 @@ test.describe('Base page tests', () => {
       expect(await lvl0Links.count()).toBeGreaterThan(0);
       for (let i = 0; i < (await lvl0Links.count()); i++) {
         const lvl0Text = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
-        await expect(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.TopNav[lvl0Text]}`);
+        await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.TopNav[lvl0Text]}`);
 
         // This section of the test isn't as neat as I would have liked. I wanted to verify the submenu levels individually e.g Women has Tops and Bottoms as level 1 menu items each with individual submenus. However, the DOM makes that awkward and as I am using a 3rd-party website I can't edit the DOM to add suitable locators/attributes as I would with a website under my control
         if (lvl0Text !== 'WhatsNew' && lvl0Text !== 'Sale') {
@@ -85,7 +85,7 @@ test.describe('Base page tests', () => {
           expect(await subMenuLinks.count()).toBeGreaterThan(0);
           for (let j = 0; j < (await subMenuLinks.count()); j++) {
             const subMenuText = (await subMenuLinks.nth(j).innerText()).replace(/\W+/g, '');
-            await expect(subMenuLinks.nth(j)).toHaveAttribute(
+            await expect.soft(subMenuLinks.nth(j)).toHaveAttribute(
               'href',
               `${baseURL}${Links.TopNav[`${lvl0Text}SubMenu`][subMenuText]}`,
             );
@@ -96,11 +96,12 @@ test.describe('Base page tests', () => {
 
     test('Footer links', async ({ baseURL }) => {
       const footerLinks = basePage.pageFooterLink;
+      expect(await footerLinks.count()).toBeGreaterThan(0);
       // The first link in the footer has a different base URL to the others so test it separately
-      await expect(footerLinks.nth(0)).toHaveAttribute('href', `${Links.Footer['Notes']}`);
+      await expect.soft(footerLinks.nth(0)).toHaveAttribute('href', `${Links.Footer['Notes']}`);
       for (let i = 1; i < (await footerLinks.count()); i++) {
         const linkText = (await footerLinks.nth(i).innerText()).replace(/\W+/g, '').replace('and', '');
-        await expect(footerLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Footer[linkText]}`);
+        await expect.soft(footerLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Footer[linkText]}`);
       }
     });
   });

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -15,64 +15,64 @@ test.describe('Home page tests', () => {
     // The tests could be combined but I have split them here to make them easier to read and maintain
 
     test('Main page elements displayed', async () => {
-      await expect(homePage.globalMessage).toBeVisible();
-      await expect(homePage.pageHeader).toBeVisible();
-      await expect(homePage.topNav).toBeVisible();
-      await expect(homePage.mainContent).toBeVisible();
-      await expect(homePage.contentHeading).toBeVisible();
-      await expect(homePage.productsGrid).toBeVisible();
-      await expect(homePage.pageFooter).toBeVisible();
-      await expect(homePage.copyrightFooter).toBeVisible();
+      await expect.soft(homePage.globalMessage).toBeVisible();
+      await expect.soft(homePage.pageHeader).toBeVisible();
+      await expect.soft(homePage.topNav).toBeVisible();
+      await expect.soft(homePage.mainContent).toBeVisible();
+      await expect.soft(homePage.contentHeading).toBeVisible();
+      await expect.soft(homePage.productsGrid).toBeVisible();
+      await expect.soft(homePage.pageFooter).toBeVisible();
+      await expect.soft(homePage.copyrightFooter).toBeVisible();
 
-      await expect(homePage.promoBlock).toHaveCount(6);
-      await expect(homePage.productItem).toHaveCount(6);
+      await expect.soft(homePage.promoBlock).toHaveCount(6);
+      await expect.soft(homePage.productItem).toHaveCount(6);
     });
 
     test('Element styling', async () => {
-      await expect(homePage.mainContent).toHaveCSS('color', Colors.DarkGrey);
+      await expect.soft(homePage.mainContent).toHaveCSS('color', Colors.DarkGrey);
     });
 
     test('Text content of page elements', async () => {
       const promoBlocks = homePage.promoBlock;
       expect(await promoBlocks.count()).toBeGreaterThan(0);
       for (let i = 0; i < (await promoBlocks.count()); i++) {
-        await expect(promoBlocks.nth(i)).toHaveText(ExpectedText.PromoBlocks[i]);
+        await expect.soft(promoBlocks.nth(i)).toHaveText(ExpectedText.PromoBlocks[i]);
       }
-      await expect(homePage.contentHeading).toHaveText(ExpectedText.ContentHeading);
+      await expect.soft(homePage.contentHeading).toHaveText(ExpectedText.ContentHeading);
     });
 
     test('Product item details', async () => {
       const productItems = homePage.productItem;
       expect(await productItems.count()).toBeGreaterThan(0);
       for (let i = 0; i < (await productItems.count()); i++) {
-        await expect(homePage.getProductItemDetails(i, ProductDetails.Name)).toHaveText(
+        await expect.soft(homePage.getProductItemDetails(i, ProductDetails.Name)).toHaveText(
           ProductItemDetails.Products[i].title,
         );
         if (ProductItemDetails.Products[i].rating) {
-          await expect(homePage.getProductItemDetails(i, ProductDetails.Rating)).toHaveText(
+          await expect.soft(homePage.getProductItemDetails(i, ProductDetails.Rating)).toHaveText(
             ProductItemDetails.Products[i].rating!,
           );
         }
         if (ProductItemDetails.Products[i].reviews) {
-          await expect(homePage.getProductItemDetails(i, ProductDetails.Reviews)).toHaveText(
+          await expect.soft(homePage.getProductItemDetails(i, ProductDetails.Reviews)).toHaveText(
             ProductItemDetails.Products[i].reviews!,
           );
         }
-        await expect(homePage.getProductItemDetails(i, ProductDetails.Price)).toHaveText(
+        await expect.soft(homePage.getProductItemDetails(i, ProductDetails.Price)).toHaveText(
           ProductItemDetails.Products[i].price,
         );
         if (ProductItemDetails.Products[i].sizes) {
           const sizes = homePage.getProductItemDetails(i, ProductDetails.Sizes);
           expect(await sizes.count()).toBeGreaterThan(0);
           for (let j = 0; j < (await sizes.count()); j++) {
-            await expect(sizes.nth(j)).toHaveText(ProductItemDetails.Products[i].sizes![j]);
+            await expect.soft(sizes.nth(j)).toHaveText(ProductItemDetails.Products[i].sizes![j]);
           }
         }
         if (ProductItemDetails.Products[i].colors) {
           const colors = homePage.getProductItemDetails(i, ProductDetails.Colors);
           expect(await colors.count()).toBeGreaterThan(0);
           for (let j = 0; j < (await colors.count()); j++) {
-            await expect(colors.nth(j)).toHaveCSS('background-color', ProductItemDetails.Products[i].colors![j]);
+            await expect.soft(colors.nth(j)).toHaveCSS('background-color', ProductItemDetails.Products[i].colors![j]);
           }
         }
       }

--- a/tests/specs/signInPage.spec.ts
+++ b/tests/specs/signInPage.spec.ts
@@ -19,54 +19,54 @@ test.describe('Sign in page tests', () => {
         const accountPage = new AccountPage(page);
         await signInPage.loginAs(dummyCustomer.email, dummyCustomer.password);
         await expect(page).toHaveURL(`${baseURL}${accountPage.url}`);
-        await expect(accountPage.greeting).toHaveText(GreetingText(dummyCustomer.name));
+        await expect.soft(accountPage.greeting).toHaveText(GreetingText(dummyCustomer.name));
       });
     });
 
     test.describe('Unsuccessful logins', () => {
       test('Invalid credentials', async ({ page }) => {
         await signInPage.loginAs(unregisteredUser.email, unregisteredUser.password);
-        await expect(signInPage.errorMessage).toBeVisible();
-        await expect(signInPage.errorMessage).toHaveText(ErrorMessages.InvalidCredentials);
+        await expect.soft(signInPage.errorMessage).toBeVisible();
+        await expect.soft(signInPage.errorMessage).toHaveText(ErrorMessages.InvalidCredentials);
         await expect(page).toHaveURL(signInPage.url);
       });
 
       test('Missing credentials', async ({ page }) => {
         await signInPage.loginButton.click();
-        await expect(signInPage.errorMessage).not.toBeVisible();
-        await expect(signInPage.emailInputError).toBeVisible();
-        await expect(signInPage.emailInputError).toHaveText(ErrorMessages.MissingInput);
-        await expect(signInPage.passwordInputError).toBeVisible();
-        await expect(signInPage.passwordInputError).toHaveText(ErrorMessages.MissingInput);
+        await expect.soft(signInPage.errorMessage).not.toBeVisible();
+        await expect.soft(signInPage.emailInputError).toBeVisible();
+        await expect.soft(signInPage.emailInputError).toHaveText(ErrorMessages.MissingInput);
+        await expect.soft(signInPage.passwordInputError).toBeVisible();
+        await expect.soft(signInPage.passwordInputError).toHaveText(ErrorMessages.MissingInput);
         await expect(page).toHaveURL(signInPage.url);
       });
 
       test('Missing username', async ({ page }) => {
         await signInPage.passwordInput.fill(dummyCustomer.password);
         await signInPage.loginButton.click();
-        await expect(signInPage.errorMessage).not.toBeVisible();
-        await expect(signInPage.emailInputError).toBeVisible();
-        await expect(signInPage.emailInputError).toHaveText(ErrorMessages.MissingInput);
-        await expect(signInPage.passwordInputError).not.toBeVisible();
+        await expect.soft(signInPage.errorMessage).not.toBeVisible();
+        await expect.soft(signInPage.emailInputError).toBeVisible();
+        await expect.soft(signInPage.emailInputError).toHaveText(ErrorMessages.MissingInput);
+        await expect.soft(signInPage.passwordInputError).not.toBeVisible();
         await expect(page).toHaveURL(signInPage.url);
       });
 
       test('Missing password', async ({ page }) => {
         await signInPage.emailInput.fill(dummyCustomer.email);
         await signInPage.loginButton.click();
-        await expect(signInPage.errorMessage).not.toBeVisible();
-        await expect(signInPage.emailInputError).not.toBeVisible();
-        await expect(signInPage.passwordInputError).toBeVisible();
-        await expect(signInPage.passwordInputError).toHaveText(ErrorMessages.MissingInput);
+        await expect.soft(signInPage.errorMessage).not.toBeVisible();
+        await expect.soft(signInPage.emailInputError).not.toBeVisible();
+        await expect.soft(signInPage.passwordInputError).toBeVisible();
+        await expect.soft(signInPage.passwordInputError).toHaveText(ErrorMessages.MissingInput);
         await expect(page).toHaveURL(signInPage.url);
       });
 
       test('Invalid email', async ({ page }) => {
         await signInPage.emailInput.fill('dummy.example@');
         await signInPage.loginButton.click();
-        await expect(signInPage.errorMessage).not.toBeVisible();
-        await expect(signInPage.emailInputError).toBeVisible();
-        await expect(signInPage.emailInputError).toHaveText(ErrorMessages.InvalidEmail);
+        await expect.soft(signInPage.errorMessage).not.toBeVisible();
+        await expect.soft(signInPage.emailInputError).toBeVisible();
+        await expect.soft(signInPage.emailInputError).toHaveText(ErrorMessages.InvalidEmail);
         await expect(page).toHaveURL(signInPage.url);
       });
     });
@@ -77,45 +77,45 @@ test.describe('Sign in page tests', () => {
     // The tests could be combined but I have split them here to make them easier to read and maintain
 
     test('Main page elements displayed', async () => {
-      await expect(signInPage.globalMessage).toBeVisible();
-      await expect(signInPage.pageHeader).toBeVisible();
-      await expect(signInPage.topNav).toBeVisible();
-      await expect(signInPage.pageTitle).toBeVisible();
-      await expect(signInPage.existingCustomerBlock).toBeVisible();
-      await expect(signInPage.emailInput).toBeVisible();
-      await expect(signInPage.passwordInput).toBeVisible();
-      await expect(signInPage.loginButton).toBeVisible();
-      await expect(signInPage.forgottenPasswordLink).toBeVisible();
-      await expect(signInPage.newCustomerBlock).toBeVisible();
-      await expect(signInPage.createAccountButton).toBeVisible();
-      await expect(signInPage.pageFooter).toBeVisible();
-      await expect(signInPage.copyrightFooter).toBeVisible();
+      await expect.soft(signInPage.globalMessage).toBeVisible();
+      await expect.soft(signInPage.pageHeader).toBeVisible();
+      await expect.soft(signInPage.topNav).toBeVisible();
+      await expect.soft(signInPage.pageTitle).toBeVisible();
+      await expect.soft(signInPage.existingCustomerBlock).toBeVisible();
+      await expect.soft(signInPage.emailInput).toBeVisible();
+      await expect.soft(signInPage.passwordInput).toBeVisible();
+      await expect.soft(signInPage.loginButton).toBeVisible();
+      await expect.soft(signInPage.forgottenPasswordLink).toBeVisible();
+      await expect.soft(signInPage.newCustomerBlock).toBeVisible();
+      await expect.soft(signInPage.createAccountButton).toBeVisible();
+      await expect.soft(signInPage.pageFooter).toBeVisible();
+      await expect.soft(signInPage.copyrightFooter).toBeVisible();
     });
 
     test('Element styling', async () => {
-      await expect(signInPage.mainContentArea).toHaveCSS('color', Colors.DarkGrey);
-      await expect(signInPage.loginButton).toHaveClass(/primary/);
-      await expect(signInPage.loginButton).toHaveCSS('background-color', Colors.Blue);
-      await expect(signInPage.loginButton).toHaveCSS('color', Colors.White);
-      await expect(signInPage.forgottenPasswordLink).toHaveCSS('color', Colors.LinkBlue);
-      await expect(signInPage.createAccountButton).toHaveClass(/primary/);
-      await expect(signInPage.createAccountButton).toHaveCSS('background-color', Colors.Blue);
-      await expect(signInPage.createAccountButton).toHaveCSS('color', Colors.White);
+      await expect.soft(signInPage.mainContentArea).toHaveCSS('color', Colors.DarkGrey);
+      await expect.soft(signInPage.loginButton).toHaveClass(/primary/);
+      await expect.soft(signInPage.loginButton).toHaveCSS('background-color', Colors.Blue);
+      await expect.soft(signInPage.loginButton).toHaveCSS('color', Colors.White);
+      await expect.soft(signInPage.forgottenPasswordLink).toHaveCSS('color', Colors.LinkBlue);
+      await expect.soft(signInPage.createAccountButton).toHaveClass(/primary/);
+      await expect.soft(signInPage.createAccountButton).toHaveCSS('background-color', Colors.Blue);
+      await expect.soft(signInPage.createAccountButton).toHaveCSS('color', Colors.White);
     });
 
     test('Text content of page elements', async () => {
-      await expect(signInPage.pageTitle).toHaveText(ExpectedText.PageTitle);
-      await expect(signInPage.existingCustomerHeading).toHaveText(ExpectedText.ExistingCustomerHeading);
-      await expect(signInPage.existingCustomerSubheading).toHaveText(ExpectedText.ExistingCustomerSubheading);
-      await expect(signInPage.emailInputLabel).toHaveText(ExpectedText.EmailInputLabel);
-      await expect(signInPage.emailInput).toBeEmpty();
-      await expect(signInPage.passwordInputLabel).toHaveText(ExpectedText.PasswordInputLabel);
-      await expect(signInPage.passwordInput).toBeEmpty();
-      await expect(signInPage.loginButton).toHaveText(ExpectedText.SignInButton);
-      await expect(signInPage.forgottenPasswordLink).toHaveText(ExpectedText.ForgottenPasswordLink);
-      await expect(signInPage.newCustomerHeading).toHaveText(ExpectedText.NewCustomerHeading);
-      await expect(signInPage.newCustomerContent).toHaveText(ExpectedText.NewCustomerContent);
-      await expect(signInPage.createAccountButton).toHaveText(ExpectedText.CreateAccountButton);
+      await expect.soft(signInPage.pageTitle).toHaveText(ExpectedText.PageTitle);
+      await expect.soft(signInPage.existingCustomerHeading).toHaveText(ExpectedText.ExistingCustomerHeading);
+      await expect.soft(signInPage.existingCustomerSubheading).toHaveText(ExpectedText.ExistingCustomerSubheading);
+      await expect.soft(signInPage.emailInputLabel).toHaveText(ExpectedText.EmailInputLabel);
+      await expect.soft(signInPage.emailInput).toBeEmpty();
+      await expect.soft(signInPage.passwordInputLabel).toHaveText(ExpectedText.PasswordInputLabel);
+      await expect.soft(signInPage.passwordInput).toBeEmpty();
+      await expect.soft(signInPage.loginButton).toHaveText(ExpectedText.SignInButton);
+      await expect.soft(signInPage.forgottenPasswordLink).toHaveText(ExpectedText.ForgottenPasswordLink);
+      await expect.soft(signInPage.newCustomerHeading).toHaveText(ExpectedText.NewCustomerHeading);
+      await expect.soft(signInPage.newCustomerContent).toHaveText(ExpectedText.NewCustomerContent);
+      await expect.soft(signInPage.createAccountButton).toHaveText(ExpectedText.CreateAccountButton);
     });
 
     test('Visual test', async ({page}) => {


### PR DESCRIPTION
Playwright allows what are known as soft assertions. These are assertions on a web element that do not terminate test execution if they fail but still mark the test as failing. The advantage of such assertions is if there have been a number of changes that would cause a test to fail all assertions will still be executed so one can see the full extent of the failures, not just the first failing assertion. Soft assertions are especially useful when asserting against things like text content or element styling. However, some assertions should still be the traditional "hard" style assertion as one would want the test execution to terminate if such an assertion fails. For example, the test suite includes assertions that the number of links within topnav submenus is greater than 0 - this should be a hard assertion as I want the test to fail if this is not the case, otherwise there is no point continuing to run the rest of the test.