### PR TITLE
Rename topnav

### DIFF
--- a/tests/data/basePage.ts
+++ b/tests/data/basePage.ts
@@ -3,7 +3,7 @@ export const ExpectedText = {
     'This is a demo store to test your test automaiton scripts. No orders will be fulfilled. If you are facing any issue, email us at hello@softwaretestingboard.com.',
   Banner: 'Skip to Content Click “Write for us” link in the footer to submit a guest post Sign In Create an Account',
   Search: 'Search entire store here...',
-  TopNav: ["What's New", 'Women', 'Men', 'Gear', 'Training', 'Sale'],
+  Topnav: ["What's New", 'Women', 'Men', 'Gear', 'Training', 'Sale'],
   FooterLinks: [
     'Notes',
     'Practice API Testing using Magento 2',
@@ -23,7 +23,7 @@ export const enum GlobalMessageStyle {
   FontWeight = '400',
 }
 
-const TopNavLvl0 = {
+const TopnavLvl0 = {
   WhatsNew: '/what-is-new.html',
   Women: '/women.html',
   Men: '/men.html',
@@ -69,8 +69,8 @@ export const Links = {
   CreateAnAccount: '/customer/account/create/',
   Logo: '/',
   Cart: '/checkout/cart/',
-  TopNav: {
-    ...TopNavLvl0,
+  Topnav: {
+    ...TopnavLvl0,
     WomenSubMenu: {
       ...WomenSubMenu,
     },

--- a/tests/pages/basePage.ts
+++ b/tests/pages/basePage.ts
@@ -10,10 +10,10 @@ export default class BasePage {
   readonly logoLink: Locator;
   readonly searchInput: Locator;
   readonly cartLink: Locator;
-  readonly topNav: Locator;
-  readonly topNavLink: Locator;
-  readonly topNavLvl0Link: Locator;
-  readonly adsWidget: Locator
+  readonly topnav: Locator;
+  readonly topnavLink: Locator;
+  readonly topnavLvl0Link: Locator;
+  readonly adsWidget: Locator;
   readonly pageFooter: Locator;
   readonly pageFooterLink: Locator;
   readonly copyrightFooter: Locator;
@@ -27,10 +27,10 @@ export default class BasePage {
     this.logoLink = page.locator('a.logo');
     this.searchInput = page.locator('input#search');
     this.cartLink = page.locator('a.showcart');
-    this.topNav = page.locator('.nav-sections');
-    this.topNavLink = this.topNav.getByRole('menuitem');
-    this.topNavLvl0Link = this.topNav.locator('li.level0').getByRole('menuitem');
-    this.adsWidget = page.locator('.widget').filter({has: page.locator('ins.adsbygoogle')});
+    this.topnav = page.locator('.nav-sections');
+    this.topnavLink = this.topnav.getByRole('menuitem');
+    this.topnavLvl0Link = this.topnav.locator('li.level0').getByRole('menuitem');
+    this.adsWidget = page.locator('.widget').filter({ has: page.locator('ins.adsbygoogle') });
     this.pageFooter = page.locator('footer.page-footer');
     this.pageFooterLink = this.pageFooter.locator('li a');
     this.copyrightFooter = page.locator('.copyright');
@@ -43,7 +43,7 @@ export default class BasePage {
     }
   }
 
-  async getTopNavSubMenuLinks(lvl0Index: number): Promise<Locator> {
-    return this.topNavLvl0Link.nth(lvl0Index).locator('..').locator('li.level1 a');
+  async getTopnavSubMenuLinks(lvl0Index: number): Promise<Locator> {
+    return this.topnavLvl0Link.nth(lvl0Index).locator('..').locator('li.level1 a');
   }
 }

--- a/tests/specs/basePage.spec.ts
+++ b/tests/specs/basePage.spec.ts
@@ -19,7 +19,7 @@ test.describe('Base page tests', () => {
     test('Common page elements displayed', async () => {
       await expect.soft(basePage.globalMessage).toBeVisible();
       await expect.soft(basePage.pageHeader).toBeVisible();
-      await expect.soft(basePage.topNav).toBeVisible();
+      await expect.soft(basePage.topnav).toBeVisible();
       await expect.soft(basePage.pageFooter).toBeVisible();
       await expect.soft(basePage.copyrightFooter).toBeVisible();
     });
@@ -31,8 +31,8 @@ test.describe('Base page tests', () => {
       await expect.soft(basePage.globalMessage).toHaveCSS('font-weight', GlobalMessageStyle.FontWeight);
       await expect.soft(basePage.banner).toHaveCSS('background-color', Colors.Grey);
       await expect.soft(basePage.banner).toHaveCSS('color', Colors.White);
-      await expect.soft(basePage.topNav).toHaveCSS('background-color', Colors.LightGrey);
-      await expect.soft(basePage.topNav).toHaveCSS('color', Colors.DarkGrey);
+      await expect.soft(basePage.topnav).toHaveCSS('background-color', Colors.LightGrey);
+      await expect.soft(basePage.topnav).toHaveCSS('color', Colors.DarkGrey);
       await expect.soft(basePage.pageFooter).toHaveCSS('background-color', Colors.LighterGrey);
       await expect.soft(basePage.pageFooter).toHaveCSS('color', Colors.DarkGrey);
       await expect.soft(basePage.copyrightFooter).toHaveCSS('background-color', Colors.Grey);
@@ -44,9 +44,9 @@ test.describe('Base page tests', () => {
       await expect.soft(basePage.banner).toHaveText(ExpectedText.Banner);
       await expect.soft(basePage.searchInput).toBeEmpty();
       await expect.soft(basePage.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
-      const topNavLinks = basePage.topNavLvl0Link;
-      for (let i = 0; i < (await elementCount(topNavLinks)); i++) {
-        await expect.soft(topNavLinks.nth(i)).toHaveText(ExpectedText.TopNav[i]);
+      const topnavLinks = basePage.topnavLvl0Link;
+      for (let i = 0; i < (await elementCount(topnavLinks)); i++) {
+        await expect.soft(topnavLinks.nth(i)).toHaveText(ExpectedText.Topnav[i]);
       }
       const footerLinks = basePage.pageFooterLink;
       for (let i = 0; i < (await elementCount(footerLinks)); i++) {
@@ -72,20 +72,20 @@ test.describe('Base page tests', () => {
       await expect.soft(basePage.cartLink).toHaveAttribute('href', `${baseURL}${Links.Cart}`);
     });
 
-    test('TopNav links', async ({ baseURL }) => {
-      const lvl0Links = basePage.topNavLvl0Link;
+    test('Topnav links', async ({ baseURL }) => {
+      const lvl0Links = basePage.topnavLvl0Link;
       for (let i = 0; i < (await elementCount(lvl0Links)); i++) {
         const lvl0Text = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
-        await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.TopNav[lvl0Text]}`);
+        await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0Text]}`);
 
         // This section of the test isn't as neat as I would have liked. I wanted to verify the submenu levels individually e.g Women has Tops and Bottoms as level 1 menu items each with individual submenus. However, the DOM makes that awkward and as I am using a 3rd-party website I can't edit the DOM to add suitable locators/attributes as I would with a website under my control
         if (lvl0Text !== 'WhatsNew' && lvl0Text !== 'Sale') {
-          const subMenuLinks = await basePage.getTopNavSubMenuLinks(i);
+          const subMenuLinks = await basePage.getTopnavSubMenuLinks(i);
           for (let j = 0; j < (await elementCount(subMenuLinks)); j++) {
             const subMenuText = (await subMenuLinks.nth(j).innerText()).replace(/\W+/g, '');
             await expect
               .soft(subMenuLinks.nth(j))
-              .toHaveAttribute('href', `${baseURL}${Links.TopNav[`${lvl0Text}SubMenu`][subMenuText]}`);
+              .toHaveAttribute('href', `${baseURL}${Links.Topnav[`${lvl0Text}SubMenu`][subMenuText]}`);
           }
         }
       }

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -20,7 +20,7 @@ test.describe('Home page tests', () => {
     test('Main page elements displayed', async () => {
       await expect.soft(homePage.globalMessage).toBeVisible();
       await expect.soft(homePage.pageHeader).toBeVisible();
-      await expect.soft(homePage.topNav).toBeVisible();
+      await expect.soft(homePage.topnav).toBeVisible();
       await expect.soft(homePage.mainContent).toBeVisible();
       await expect.soft(homePage.contentHeading).toBeVisible();
       await expect.soft(homePage.productsGrid).toBeVisible();

--- a/tests/specs/myAccountPage.spec.ts
+++ b/tests/specs/myAccountPage.spec.ts
@@ -22,7 +22,7 @@ test.describe('Account page tests', () => {
     test('Main page elements displayed', async () => {
       await expect.soft(accountPage.globalMessage).toBeVisible();
       await expect.soft(accountPage.pageHeader).toBeVisible();
-      await expect.soft(accountPage.topNav).toBeVisible();
+      await expect.soft(accountPage.topnav).toBeVisible();
       await expect.soft(accountPage.mainBlock).toBeVisible();
       await expect.soft(accountPage.primarySidenav).toBeVisible();
       await expect.soft(accountPage.secondarySidenav).toBeVisible();

--- a/tests/specs/signInPage.spec.ts
+++ b/tests/specs/signInPage.spec.ts
@@ -79,7 +79,7 @@ test.describe('Sign in page tests', () => {
     test('Main page elements displayed', async () => {
       await expect.soft(signInPage.globalMessage).toBeVisible();
       await expect.soft(signInPage.pageHeader).toBeVisible();
-      await expect.soft(signInPage.topNav).toBeVisible();
+      await expect.soft(signInPage.topnav).toBeVisible();
       await expect.soft(signInPage.pageTitle).toBeVisible();
       await expect.soft(signInPage.existingCustomerBlock).toBeVisible();
       await expect.soft(signInPage.emailInput).toBeVisible();


### PR DESCRIPTION
Rename "TopNav" to "Topnav" and "topNav" to "topnav" as it is a more common capitalisation/spelling and is then consistent with Sidenav/sidenav as added in the tests for the "My Account" page