### PR TITLE
Split BasePage

### DIFF
--- a/tests/data/basePage.ts
+++ b/tests/data/basePage.ts
@@ -1,97 +1,9 @@
 export const ExpectedText = {
   GlobalMessage:
     'This is a demo store to test your test automaiton scripts. No orders will be fulfilled. If you are facing any issue, email us at hello@softwaretestingboard.com.',
-  Banner: 'Skip to Content Click “Write for us” link in the footer to submit a guest post Sign In Create an Account',
-  Search: 'Search entire store here...',
-  Topnav: ["What's New", 'Women', 'Men', 'Gear', 'Training', 'Sale'],
-  FooterLinks: [
-    'Notes',
-    'Practice API Testing using Magento 2',
-    'Write for us',
-    'Subscribe',
-    'Search Terms',
-    'Privacy and Cookie Policy',
-    'Advanced Search',
-    'Orders and Returns',
-  ],
-  Copyright:
-    'We know you have an assignment to complete. If this site is not functioning as expected, drop us an email. Copyright © 2013-present Magento, Inc. All rights reserved.',
 };
 
 export const enum GlobalMessageStyle {
   FontSize = '13px',
   FontWeight = '400',
 }
-
-const TopnavLvl0 = {
-  WhatsNew: '/what-is-new.html',
-  Women: '/women.html',
-  Men: '/men.html',
-  Gear: '/gear.html',
-  Training: '/training.html',
-  Sale: '/sale.html',
-};
-
-const WomenSubMenu = {
-  Tops: '/women/tops-women.html',
-  Jackets: '/women/tops-women/jackets-women.html',
-  HoodiesSweatshirts: '/women/tops-women/hoodies-and-sweatshirts-women.html',
-  Tees: '/women/tops-women/tees-women.html',
-  BrasTanks: '/women/tops-women/tanks-women.html',
-  Bottoms: '/women/bottoms-women.html',
-  Pants: '/women/bottoms-women/pants-women.html',
-  Shorts: '/women/bottoms-women/shorts-women.html',
-};
-
-const MenSubMenu = {
-  Tops: '/men/tops-men.html',
-  Jackets: '/men/tops-men/jackets-men.html',
-  HoodiesSweatshirts: '/men/tops-men/hoodies-and-sweatshirts-men.html',
-  Tees: '/men/tops-men/tees-men.html',
-  Tanks: '/men/tops-men/tanks-men.html',
-  Bottoms: '/men/bottoms-men.html',
-  Pants: '/men/bottoms-men/pants-men.html',
-  Shorts: '/men/bottoms-men/shorts-men.html',
-};
-
-const GearSubMenu = {
-  Bags: '/gear/bags.html',
-  FitnessEquipment: '/gear/fitness-equipment.html',
-  Watches: '/gear/watches.html',
-};
-
-const TrainingSubMenu = {
-  VideoDownload: '/training/training-video.html',
-};
-
-export const Links = {
-  SignIn: '/customer/account/login/referer/*/',
-  CreateAnAccount: '/customer/account/create/',
-  Logo: '/',
-  Cart: '/checkout/cart/',
-  Topnav: {
-    ...TopnavLvl0,
-    WomenSubMenu: {
-      ...WomenSubMenu,
-    },
-    MenSubMenu: {
-      ...MenSubMenu,
-    },
-    GearSubMenu: {
-      ...GearSubMenu,
-    },
-    TrainingSubMenu: {
-      ...TrainingSubMenu,
-    },
-  },
-  Footer: [
-    'https://softwaretestingboard.com/magento-store-notes/?utm_source=magento_store&utm_medium=banner&utm_campaign=notes_promo&utm_id=notes_promotion',
-    'https://softwaretestingboard.com/practice-api-testing-using-magento-2/?utm_source=magento_store&utm_medium=banner&utm_campaign=notes_promo&utm_id=API_Testing_Promo',
-    'https://softwaretestingboard.com/write-for-us/?utm_source=magento_store&utm_medium=banner&utm_campaign=notes_promo&utm_id=write4us',
-    'https://softwaretestingboard.com/subscribe/?utm_source=magento_store&utm_medium=banner&utm_campaign=notes_promo&utm_id=email_subscribe',
-    `/search/term/popular/`,
-    `/privacy-policy-cookie-restriction-mode/`,
-    `/catalogsearch/advanced/`,
-    `/sales/guest/form/`,
-  ],
-};

--- a/tests/data/pageFooter.ts
+++ b/tests/data/pageFooter.ts
@@ -1,0 +1,25 @@
+export const ExpectedText = {
+  FooterLinks: [
+    'Notes',
+    'Practice API Testing using Magento 2',
+    'Write for us',
+    'Subscribe',
+    'Search Terms',
+    'Privacy and Cookie Policy',
+    'Advanced Search',
+    'Orders and Returns',
+  ],
+  Copyright:
+    'We know you have an assignment to complete. If this site is not functioning as expected, drop us an email. Copyright © 2013-present Magento, Inc. All rights reserved.',
+};
+
+export const FooterLinks = [
+  'https://softwaretestingboard.com/magento-store-notes/?utm_source=magento_store&utm_medium=banner&utm_campaign=notes_promo&utm_id=notes_promotion',
+  'https://softwaretestingboard.com/practice-api-testing-using-magento-2/?utm_source=magento_store&utm_medium=banner&utm_campaign=notes_promo&utm_id=API_Testing_Promo',
+  'https://softwaretestingboard.com/write-for-us/?utm_source=magento_store&utm_medium=banner&utm_campaign=notes_promo&utm_id=write4us',
+  'https://softwaretestingboard.com/subscribe/?utm_source=magento_store&utm_medium=banner&utm_campaign=notes_promo&utm_id=email_subscribe',
+  `/search/term/popular/`,
+  `/privacy-policy-cookie-restriction-mode/`,
+  `/catalogsearch/advanced/`,
+  `/sales/guest/form/`,
+];

--- a/tests/data/pageHeader.ts
+++ b/tests/data/pageHeader.ts
@@ -1,0 +1,68 @@
+export const ExpectedText = {
+  Banner: 'Skip to Content Click “Write for us” link in the footer to submit a guest post Sign In Create an Account',
+  Search: 'Search entire store here...',
+  Topnav: ["What's New", 'Women', 'Men', 'Gear', 'Training', 'Sale'],
+};
+
+const TopnavLvl0 = {
+  WhatsNew: '/what-is-new.html',
+  Women: '/women.html',
+  Men: '/men.html',
+  Gear: '/gear.html',
+  Training: '/training.html',
+  Sale: '/sale.html',
+};
+
+const WomenSubMenu = {
+  Tops: '/women/tops-women.html',
+  Jackets: '/women/tops-women/jackets-women.html',
+  HoodiesSweatshirts: '/women/tops-women/hoodies-and-sweatshirts-women.html',
+  Tees: '/women/tops-women/tees-women.html',
+  BrasTanks: '/women/tops-women/tanks-women.html',
+  Bottoms: '/women/bottoms-women.html',
+  Pants: '/women/bottoms-women/pants-women.html',
+  Shorts: '/women/bottoms-women/shorts-women.html',
+};
+
+const MenSubMenu = {
+  Tops: '/men/tops-men.html',
+  Jackets: '/men/tops-men/jackets-men.html',
+  HoodiesSweatshirts: '/men/tops-men/hoodies-and-sweatshirts-men.html',
+  Tees: '/men/tops-men/tees-men.html',
+  Tanks: '/men/tops-men/tanks-men.html',
+  Bottoms: '/men/bottoms-men.html',
+  Pants: '/men/bottoms-men/pants-men.html',
+  Shorts: '/men/bottoms-men/shorts-men.html',
+};
+
+const GearSubMenu = {
+  Bags: '/gear/bags.html',
+  FitnessEquipment: '/gear/fitness-equipment.html',
+  Watches: '/gear/watches.html',
+};
+
+const TrainingSubMenu = {
+  VideoDownload: '/training/training-video.html',
+};
+
+export const Links = {
+  SignIn: '/customer/account/login/referer/*/',
+  CreateAnAccount: '/customer/account/create/',
+  Logo: '/',
+  Cart: '/checkout/cart/',
+  Topnav: {
+    ...TopnavLvl0,
+    WomenSubMenu: {
+      ...WomenSubMenu,
+    },
+    MenSubMenu: {
+      ...MenSubMenu,
+    },
+    GearSubMenu: {
+      ...GearSubMenu,
+    },
+    TrainingSubMenu: {
+      ...TrainingSubMenu,
+    },
+  },
+};

--- a/tests/pages/basePage.ts
+++ b/tests/pages/basePage.ts
@@ -1,49 +1,28 @@
 import { Locator, Page } from '@playwright/test';
+import PageHeader from './pageHeader';
+import PageFooter from './pageFooter';
 
 export default class BasePage {
   readonly url: string;
   readonly page: Page;
   readonly globalMessage: Locator;
-  readonly pageHeader: Locator;
-  readonly banner: Locator;
-  readonly bannerLink: Locator;
-  readonly logoLink: Locator;
-  readonly searchInput: Locator;
-  readonly cartLink: Locator;
-  readonly topnav: Locator;
-  readonly topnavLink: Locator;
-  readonly topnavLvl0Link: Locator;
+  readonly pageHeader: PageHeader;
   readonly adsWidget: Locator;
-  readonly pageFooter: Locator;
-  readonly pageFooterLink: Locator;
-  readonly copyrightFooter: Locator;
+  readonly pageFooter: PageFooter;
 
   constructor(page: Page) {
     this.page = page;
+    this.pageHeader = new PageHeader(page);
     this.globalMessage = page.locator('.global.message');
-    this.pageHeader = page.locator('header.page-header');
-    this.banner = this.pageHeader.locator('.panel.wrapper');
-    this.bannerLink = this.banner.locator('li a');
-    this.logoLink = page.locator('a.logo');
-    this.searchInput = page.locator('input#search');
-    this.cartLink = page.locator('a.showcart');
-    this.topnav = page.locator('.nav-sections');
-    this.topnavLink = this.topnav.getByRole('menuitem');
-    this.topnavLvl0Link = this.topnav.locator('li.level0').getByRole('menuitem');
     this.adsWidget = page.locator('.widget').filter({ has: page.locator('ins.adsbygoogle') });
-    this.pageFooter = page.locator('footer.page-footer');
-    this.pageFooterLink = this.pageFooter.locator('li a');
-    this.copyrightFooter = page.locator('.copyright');
+    this.pageFooter = new PageFooter(page);
   }
+
   async open(url: string) {
     // Firefox can be VERY slow to load the page it seems so use a large timeout even though it exceeds the configured test timeout for most browsers
     await this.page.goto(url, { timeout: 90000 });
     if (process.platform === 'win32') {
       await this.page.getByRole('button').getByText('Consent').click();
     }
-  }
-
-  async getTopnavSubMenuLinks(lvl0Index: number): Promise<Locator> {
-    return this.topnavLvl0Link.nth(lvl0Index).locator('..').locator('li.level1 a');
   }
 }

--- a/tests/pages/myAccountPage.ts
+++ b/tests/pages/myAccountPage.ts
@@ -3,7 +3,6 @@ import BasePage from './basePage';
 
 export class MyAccountPage extends BasePage {
   url = '/customer/account/';
-  readonly greeting: Locator;
   readonly mainContent: Locator;
   readonly mainBlock: Locator;
   readonly primarySidenav: Locator;
@@ -28,7 +27,6 @@ export class MyAccountPage extends BasePage {
 
   constructor(page: Page) {
     super(page);
-    this.greeting = this.banner.locator('.greet.welcome');
     this.mainContent = this.page.locator('#maincontent');
     this.mainBlock = this.page.locator('.column.main');
     this.primarySidenav = this.page.locator('.sidebar-main .content');

--- a/tests/pages/pageFooter.ts
+++ b/tests/pages/pageFooter.ts
@@ -1,0 +1,15 @@
+import { Locator, Page } from '@playwright/test';
+
+export default class PageFooter {
+  readonly page: Page;
+  readonly footer: Locator;
+  readonly footerLink: Locator;
+  readonly copyrightFooter: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.footer = page.locator('footer.page-footer');
+    this.footerLink = this.footer.locator('li a');
+    this.copyrightFooter = page.locator('.copyright');
+  }
+}

--- a/tests/pages/pageHeader.ts
+++ b/tests/pages/pageHeader.ts
@@ -1,0 +1,33 @@
+import { Locator, Page } from '@playwright/test';
+
+export default class PageHeader {
+  readonly page: Page;
+  readonly globalMessage: Locator;
+  readonly header: Locator;
+  readonly banner: Locator;
+  readonly bannerLink: Locator;
+  readonly logo: Locator;
+  readonly searchInput: Locator;
+  readonly cartLink: Locator;
+  readonly topnav: Locator;
+  readonly topnavLink: Locator;
+  readonly topnavLvl0Link: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.globalMessage = page.locator('.global.message');
+    this.header = page.locator('header.page-header');
+    this.banner = this.header.locator('.panel.wrapper');
+    this.bannerLink = this.banner.locator('li a');
+    this.logo = this.header.locator('a.logo');
+    this.searchInput = this.header.locator('input#search');
+    this.cartLink = this.header.locator('a.showcart');
+    this.topnav = page.locator('.nav-sections');
+    this.topnavLink = this.topnav.getByRole('menuitem');
+    this.topnavLvl0Link = this.topnav.locator('li.level0').getByRole('menuitem');
+  }
+
+  async getTopnavSubMenuLinks(lvl0Index: number): Promise<Locator> {
+    return this.topnavLvl0Link.nth(lvl0Index).locator('..').locator('li.level1 a');
+  }
+}

--- a/tests/pages/pageHeader.ts
+++ b/tests/pages/pageHeader.ts
@@ -2,10 +2,10 @@ import { Locator, Page } from '@playwright/test';
 
 export default class PageHeader {
   readonly page: Page;
-  readonly globalMessage: Locator;
   readonly header: Locator;
   readonly banner: Locator;
   readonly bannerLink: Locator;
+  readonly greeting: Locator;
   readonly logo: Locator;
   readonly searchInput: Locator;
   readonly cartLink: Locator;
@@ -15,10 +15,10 @@ export default class PageHeader {
 
   constructor(page: Page) {
     this.page = page;
-    this.globalMessage = page.locator('.global.message');
     this.header = page.locator('header.page-header');
     this.banner = this.header.locator('.panel.wrapper');
     this.bannerLink = this.banner.locator('li a');
+    this.greeting = this.banner.locator('.greet.welcome');
     this.logo = this.header.locator('a.logo');
     this.searchInput = this.header.locator('input#search');
     this.cartLink = this.header.locator('a.showcart');

--- a/tests/specs/basePage.spec.ts
+++ b/tests/specs/basePage.spec.ts
@@ -1,6 +1,5 @@
-import { ExpectedText, GlobalMessageStyle, Links } from '../data/basePage';
+import { ExpectedText, GlobalMessageStyle } from '../data/basePage';
 import { Colors } from '../data/shared';
-import { elementCount } from '../helpers/elementUtils';
 import BasePage from '../pages/basePage';
 import { test, expect } from '@playwright/test';
 
@@ -18,10 +17,10 @@ test.describe('Base page tests', () => {
 
     test('Common page elements displayed', async () => {
       await expect.soft(basePage.globalMessage).toBeVisible();
-      await expect.soft(basePage.pageHeader).toBeVisible();
-      await expect.soft(basePage.topnav).toBeVisible();
-      await expect.soft(basePage.pageFooter).toBeVisible();
-      await expect.soft(basePage.copyrightFooter).toBeVisible();
+      await expect.soft(basePage.pageHeader.header).toBeVisible();
+      await expect.soft(basePage.pageHeader.topnav).toBeVisible();
+      await expect.soft(basePage.pageFooter.footer).toBeVisible();
+      await expect.soft(basePage.pageFooter.copyrightFooter).toBeVisible();
     });
 
     test('Element styling', async () => {
@@ -29,74 +28,10 @@ test.describe('Base page tests', () => {
       await expect.soft(basePage.globalMessage).toHaveCSS('color', Colors.White);
       await expect.soft(basePage.globalMessage).toHaveCSS('font-size', GlobalMessageStyle.FontSize);
       await expect.soft(basePage.globalMessage).toHaveCSS('font-weight', GlobalMessageStyle.FontWeight);
-      await expect.soft(basePage.banner).toHaveCSS('background-color', Colors.Grey);
-      await expect.soft(basePage.banner).toHaveCSS('color', Colors.White);
-      await expect.soft(basePage.topnav).toHaveCSS('background-color', Colors.LightGrey);
-      await expect.soft(basePage.topnav).toHaveCSS('color', Colors.DarkGrey);
-      await expect.soft(basePage.pageFooter).toHaveCSS('background-color', Colors.LighterGrey);
-      await expect.soft(basePage.pageFooter).toHaveCSS('color', Colors.DarkGrey);
-      await expect.soft(basePage.copyrightFooter).toHaveCSS('background-color', Colors.Grey);
-      await expect.soft(basePage.copyrightFooter).toHaveCSS('color', Colors.White);
     });
 
     test('Text content of page elements', async () => {
       await expect.soft(basePage.globalMessage).toHaveText(ExpectedText.GlobalMessage);
-      await expect.soft(basePage.banner).toHaveText(ExpectedText.Banner);
-      await expect.soft(basePage.searchInput).toBeEmpty();
-      await expect.soft(basePage.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
-      const topnavLinks = basePage.topnavLvl0Link;
-      for (let i = 0; i < (await elementCount(topnavLinks)); i++) {
-        await expect.soft(topnavLinks.nth(i)).toHaveText(ExpectedText.Topnav[i]);
-      }
-      const footerLinks = basePage.pageFooterLink;
-      for (let i = 0; i < (await elementCount(footerLinks)); i++) {
-        await expect.soft(footerLinks.nth(i)).toHaveText(ExpectedText.FooterLinks[i]);
-      }
-      await expect.soft(basePage.copyrightFooter).toHaveText(ExpectedText.Copyright);
-    });
-  });
-
-  test.describe('Link tests', () => {
-    test('Banner links', async ({ baseURL }) => {
-      await expect.soft(basePage.bannerLink.first()).toHaveAttribute('href', new RegExp(`${baseURL}${Links.SignIn}`));
-      await expect
-        .soft(basePage.bannerLink.nth(1))
-        .toHaveAttribute('href', new RegExp(`${baseURL}${Links.CreateAnAccount}`));
-    });
-
-    test('Logo link', async ({ baseURL }) => {
-      await expect.soft(basePage.logoLink).toHaveAttribute('href', `${baseURL}${Links.Logo}`);
-    });
-
-    test('Shopping cart link', async ({ baseURL }) => {
-      await expect.soft(basePage.cartLink).toHaveAttribute('href', `${baseURL}${Links.Cart}`);
-    });
-
-    test('Topnav links', async ({ baseURL }) => {
-      const lvl0Links = basePage.topnavLvl0Link;
-      for (let i = 0; i < (await elementCount(lvl0Links)); i++) {
-        const lvl0Text = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
-        await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0Text]}`);
-
-        // This section of the test isn't as neat as I would have liked. I wanted to verify the submenu levels individually e.g Women has Tops and Bottoms as level 1 menu items each with individual submenus. However, the DOM makes that awkward and as I am using a 3rd-party website I can't edit the DOM to add suitable locators/attributes as I would with a website under my control
-        if (lvl0Text !== 'WhatsNew' && lvl0Text !== 'Sale') {
-          const subMenuLinks = await basePage.getTopnavSubMenuLinks(i);
-          for (let j = 0; j < (await elementCount(subMenuLinks)); j++) {
-            const subMenuText = (await subMenuLinks.nth(j).innerText()).replace(/\W+/g, '');
-            await expect
-              .soft(subMenuLinks.nth(j))
-              .toHaveAttribute('href', `${baseURL}${Links.Topnav[`${lvl0Text}SubMenu`][subMenuText]}`);
-          }
-        }
-      }
-    });
-
-    test('Footer links', async ({ baseURL }) => {
-      const footerLinks = basePage.pageFooterLink;
-      for (let i = 0; i < (await elementCount(footerLinks)); i++) {
-        const expectedLink = Links.Footer[i].startsWith('https') ? Links.Footer[i] : `${baseURL}${Links.Footer[i]}`;
-        await expect.soft(footerLinks.nth(i)).toHaveAttribute('href', expectedLink);
-      }
     });
   });
 });

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -19,13 +19,13 @@ test.describe('Home page tests', () => {
 
     test('Main page elements displayed', async () => {
       await expect.soft(homePage.globalMessage).toBeVisible();
-      await expect.soft(homePage.pageHeader).toBeVisible();
-      await expect.soft(homePage.topnav).toBeVisible();
+      await expect.soft(homePage.pageHeader.header).toBeVisible();
+      await expect.soft(homePage.pageHeader.topnav).toBeVisible();
       await expect.soft(homePage.mainContent).toBeVisible();
       await expect.soft(homePage.contentHeading).toBeVisible();
       await expect.soft(homePage.productsGrid).toBeVisible();
-      await expect.soft(homePage.pageFooter).toBeVisible();
-      await expect.soft(homePage.copyrightFooter).toBeVisible();
+      await expect.soft(homePage.pageFooter.footer).toBeVisible();
+      await expect.soft(homePage.pageFooter.copyrightFooter).toBeVisible();
 
       await expect.soft(homePage.promoBlock).toHaveCount(6);
       await expect.soft(homePage.productItem).toHaveCount(6);

--- a/tests/specs/myAccountPage.spec.ts
+++ b/tests/specs/myAccountPage.spec.ts
@@ -21,16 +21,16 @@ test.describe('Account page tests', () => {
 
     test('Main page elements displayed', async () => {
       await expect.soft(accountPage.globalMessage).toBeVisible();
-      await expect.soft(accountPage.pageHeader).toBeVisible();
-      await expect.soft(accountPage.topnav).toBeVisible();
+      await expect.soft(accountPage.pageHeader.header).toBeVisible();
+      await expect.soft(accountPage.pageHeader.topnav).toBeVisible();
       await expect.soft(accountPage.mainBlock).toBeVisible();
       await expect.soft(accountPage.primarySidenav).toBeVisible();
       await expect.soft(accountPage.secondarySidenav).toBeVisible();
       await expect.soft(accountPage.pageTitle).toBeVisible();
       await expect.soft(accountPage.accountInfoBlock).toBeVisible();
       await expect.soft(accountPage.addressBookBlock).toBeVisible();
-      await expect.soft(accountPage.pageFooter).toBeVisible();
-      await expect.soft(accountPage.copyrightFooter).toBeVisible();
+      await expect.soft(accountPage.pageFooter.footer).toBeVisible();
+      await expect.soft(accountPage.pageFooter.copyrightFooter).toBeVisible();
     });
 
     test('Element styling', async () => {

--- a/tests/specs/pageFooter.spec.ts
+++ b/tests/specs/pageFooter.spec.ts
@@ -1,0 +1,51 @@
+import { ExpectedText, FooterLinks } from '../data/pageFooter';
+import { Colors } from '../data/shared';
+import { elementCount } from '../helpers/elementUtils';
+import BasePage from '../pages/basePage';
+import { test, expect } from '@playwright/test';
+import PageFooter from '../pages/pageFooter';
+
+test.describe('Page footer tests', () => {
+  let pageFooter: PageFooter;
+  test.beforeEach(async ({ page }) => {
+    // Verify the common page footer elements on the home page. Any page would do here but the home page should be quickest to access
+    pageFooter = new PageFooter(page);
+    await new BasePage(page).open('/');
+  });
+
+  test.describe('Appearance tests', () => {
+    // This is an example of performing visual-style testing without actually using image comparison
+    // but asserting against various element properties
+    // The tests could be combined but I have split them here to make them easier to read and maintain
+
+    test('Common page elements displayed', async () => {
+      await expect.soft(pageFooter.footer).toBeVisible();
+      await expect.soft(pageFooter.copyrightFooter).toBeVisible();
+    });
+
+    test('Element styling', async () => {
+      await expect.soft(pageFooter.footer).toHaveCSS('background-color', Colors.LighterGrey);
+      await expect.soft(pageFooter.footer).toHaveCSS('color', Colors.DarkGrey);
+      await expect.soft(pageFooter.copyrightFooter).toHaveCSS('background-color', Colors.Grey);
+      await expect.soft(pageFooter.copyrightFooter).toHaveCSS('color', Colors.White);
+    });
+
+    test('Text content of page elements', async () => {
+      const footerLinks = pageFooter.footerLink;
+      for (let i = 0; i < (await elementCount(footerLinks)); i++) {
+        await expect.soft(footerLinks.nth(i)).toHaveText(ExpectedText.FooterLinks[i]);
+      }
+      await expect.soft(pageFooter.copyrightFooter).toHaveText(ExpectedText.Copyright);
+    });
+  });
+
+  test.describe('Link tests', () => {
+    test('Footer links', async ({ baseURL }) => {
+      const footerLinks = pageFooter.footerLink;
+      for (let i = 0; i < (await elementCount(footerLinks)); i++) {
+        const expectedLink = FooterLinks[i].startsWith('https') ? FooterLinks[i] : `${baseURL}${FooterLinks[i]}`;
+        await expect.soft(footerLinks.nth(i)).toHaveAttribute('href', expectedLink);
+      }
+    });
+  });
+});

--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -1,0 +1,86 @@
+import { ExpectedText, Links } from '../data/pageHeader';
+import { Colors } from '../data/shared';
+import { elementCount } from '../helpers/elementUtils';
+import { test, expect } from '@playwright/test';
+import PageHeader from '../pages/pageHeader';
+import BasePage from '../pages/basePage';
+
+test.describe('Page header tests', () => {
+  let pageHeader: PageHeader;
+  test.beforeEach(async ({ page }) => {
+    // Verify the common page header elements on the home page. Any page would do here but the home page should be quickest to access
+    pageHeader = new PageHeader(page);
+    await new BasePage(page).open('/');
+  });
+
+  test.describe('Appearance tests', () => {
+    // This is an example of performing visual-style testing without actually using image comparison
+    // but asserting against various element properties
+    // The tests could be combined but I have split them here to make them easier to read and maintain
+
+    test('Common page header elements displayed', async () => {
+      await expect.soft(pageHeader.header).toBeVisible();
+      await expect.soft(pageHeader.banner).toBeVisible();
+      await expect.soft(pageHeader.logo).toBeVisible();
+      await expect.soft(pageHeader.searchInput).toBeVisible();
+      await expect.soft(pageHeader.cartLink).toBeVisible();
+      await expect.soft(pageHeader.topnav).toBeVisible();
+    });
+
+    test('Element styling', async () => {
+      await expect.soft(pageHeader.banner).toHaveCSS('background-color', Colors.Grey);
+      await expect.soft(pageHeader.banner).toHaveCSS('color', Colors.White);
+      await expect.soft(pageHeader.topnav).toHaveCSS('background-color', Colors.LightGrey);
+      await expect.soft(pageHeader.topnav).toHaveCSS('color', Colors.DarkGrey);
+    });
+
+    test('Text content of page elements', async () => {
+      await expect.soft(pageHeader.banner).toHaveText(ExpectedText.Banner);
+      await expect.soft(pageHeader.searchInput).toBeEmpty();
+      await expect.soft(pageHeader.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
+      const topnavLinks = pageHeader.topnavLvl0Link;
+      for (let i = 0; i < (await elementCount(topnavLinks)); i++) {
+        await expect.soft(topnavLinks.nth(i)).toHaveText(ExpectedText.Topnav[i]);
+      }
+    });
+  });
+
+  test.describe('Link tests', () => {
+    test('Banner links', async ({ baseURL }) => {
+      await expect.soft(pageHeader.bannerLink.first()).toHaveAttribute('href', new RegExp(`${baseURL}${Links.SignIn}`));
+      await expect
+        .soft(pageHeader.bannerLink.nth(1))
+        .toHaveAttribute('href', new RegExp(`${baseURL}${Links.CreateAnAccount}`));
+    });
+
+    test('Logo link', async ({ baseURL }) => {
+      await expect.soft(pageHeader.logo).toHaveAttribute('href', `${baseURL}${Links.Logo}`);
+    });
+
+    test('Shopping cart link', async ({ baseURL }) => {
+      await expect.soft(pageHeader.cartLink).toHaveAttribute('href', `${baseURL}${Links.Cart}`);
+    });
+
+    test('Topnav links', async ({ baseURL }) => {
+      const lvl0Links = pageHeader.topnavLvl0Link;
+      for (let i = 0; i < (await elementCount(lvl0Links)); i++) {
+        const lvl0Text = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
+        await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0Text]}`);
+
+        // This section of the test isn't as neat as I would have liked. I wanted to verify the submenu levels individually
+        // e.g Women has Tops and Bottoms as level 1 menu items each with individual submenus. However, the DOM makes that
+        // awkward and as I am using a 3rd - party website I can't edit the DOM to add suitable locators/attributes as I
+        // would with a website under my control
+        if (lvl0Text !== 'WhatsNew' && lvl0Text !== 'Sale') {
+          const subMenuLinks = await pageHeader.getTopnavSubMenuLinks(i);
+          for (let j = 0; j < (await elementCount(subMenuLinks)); j++) {
+            const subMenuText = (await subMenuLinks.nth(j).innerText()).replace(/\W+/g, '');
+            await expect
+              .soft(subMenuLinks.nth(j))
+              .toHaveAttribute('href', `${baseURL}${Links.Topnav[`${lvl0Text}SubMenu`][subMenuText]}`);
+          }
+        }
+      }
+    });
+  });
+});

--- a/tests/specs/signInPage.spec.ts
+++ b/tests/specs/signInPage.spec.ts
@@ -19,7 +19,7 @@ test.describe('Sign in page tests', () => {
         const accountPage = new MyAccountPage(page);
         await signInPage.loginAs(dummyCustomer.email, dummyCustomer.password);
         await expect(page).toHaveURL(`${baseURL}${accountPage.url}`);
-        await expect.soft(accountPage.greeting).toHaveText(GreetingText(dummyCustomer.name));
+        await expect.soft(accountPage.pageHeader.greeting).toHaveText(GreetingText(dummyCustomer.name));
       });
     });
 
@@ -78,8 +78,8 @@ test.describe('Sign in page tests', () => {
 
     test('Main page elements displayed', async () => {
       await expect.soft(signInPage.globalMessage).toBeVisible();
-      await expect.soft(signInPage.pageHeader).toBeVisible();
-      await expect.soft(signInPage.topnav).toBeVisible();
+      await expect.soft(signInPage.pageHeader.header).toBeVisible();
+      await expect.soft(signInPage.pageHeader.topnav).toBeVisible();
       await expect.soft(signInPage.pageTitle).toBeVisible();
       await expect.soft(signInPage.existingCustomerBlock).toBeVisible();
       await expect.soft(signInPage.emailInput).toBeVisible();
@@ -88,8 +88,8 @@ test.describe('Sign in page tests', () => {
       await expect.soft(signInPage.forgottenPasswordLink).toBeVisible();
       await expect.soft(signInPage.newCustomerBlock).toBeVisible();
       await expect.soft(signInPage.createAccountButton).toBeVisible();
-      await expect.soft(signInPage.pageFooter).toBeVisible();
-      await expect.soft(signInPage.copyrightFooter).toBeVisible();
+      await expect.soft(signInPage.pageFooter.footer).toBeVisible();
+      await expect.soft(signInPage.pageFooter.copyrightFooter).toBeVisible();
     });
 
     test('Element styling', async () => {


### PR DESCRIPTION
Having worked with the BasePage POM more now I have realised that it would be better if the page header and footer were separate POMs rather than being part of the base page. This split makes it easier to manage any changes to the header/footer without affecting the rest of the POMs as well as making it easier to add more appropriate visual testing of the page header/footer