### PR TITLE
Declare timeouts as constants

### DIFF
--- a/tests/specs/basePage.spec.ts
+++ b/tests/specs/basePage.spec.ts
@@ -2,6 +2,10 @@ import { ExpectedText, Colors, GlobalMessageStyle } from '../data/basePage';
 import BasePage from '../pages/basePage';
 import { test, expect } from '@playwright/test';
 
+const Timeouts = {
+  Visual: 20000,
+};
+
 test.describe('Base page tests', () => {
   let basePage: BasePage;
   test.beforeEach(async ({ page }) => {
@@ -37,7 +41,7 @@ test.describe('Base page tests', () => {
   test.describe('Visual tests', () => {
     test('Default global message appearance', async () => {
       await expect(basePage.globalMessage).toHaveScreenshot('message.png', {
-        timeout: 20000,
+        timeout: Timeouts.Visual,
       });
     });
   });

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -4,6 +4,11 @@ import { ExpectedText, Products, PromoBlockLinks, SwatchOutlineStyles, Colors } 
 import { rgbToHex } from '../helpers/colorUtils';
 import { elementCount } from '../helpers/elementUtils';
 
+const Timeouts = {
+  ImageLink: 10000,
+  Visual: 20000,
+};
+
 test.describe('Home page tests', () => {
   let homePage: HomePage;
   test.beforeEach(async ({ page }) => {
@@ -153,13 +158,13 @@ test.describe('Home page tests', () => {
     test('Default page appearance', async () => {
       await expect(homePage.mainContent).toHaveScreenshot('default.png', {
         mask: [homePage.adsWidget],
-        timeout: 20000,
+        timeout: Timeouts.Visual,
       });
     });
 
     test('Product hover', async () => {
       await homePage.productItem.nth(0).hover();
-      await expect(homePage.productsGrid).toHaveScreenshot('productHover.png', { timeout: 20000 });
+      await expect(homePage.productsGrid).toHaveScreenshot('productHover.png', { timeout: Timeouts.Visual });
     });
 
     // There is no need for visual testing of the product images for the various colour options as we can verify
@@ -218,7 +223,7 @@ test.describe('Home page tests', () => {
               : `${baseURL}${mediaDir}${Products[i].images.sizes}`;
             await expect
               .soft(homePage.getProductItemElement(i, ProductItemElements.Photo))
-              .toHaveAttribute('src', imageLink, { timeout: 10000 });
+              .toHaveAttribute('src', imageLink, { timeout: Timeouts.ImageLink });
           }
         }
       }
@@ -234,7 +239,7 @@ test.describe('Home page tests', () => {
             const imageLink = `${baseURL}${mediaDir}${Products[i].images.colors[j]}`;
             await expect
               .soft(homePage.getProductItemElement(i, ProductItemElements.Photo))
-              .toHaveAttribute('src', imageLink, { timeout: 10000 });
+              .toHaveAttribute('src', imageLink, { timeout: Timeouts.ImageLink });
           }
         }
       }

--- a/tests/specs/myAccountPage.spec.ts
+++ b/tests/specs/myAccountPage.spec.ts
@@ -5,6 +5,10 @@ import SignInPage from '../pages/signInPage';
 import { dummyCustomer } from '../data/users';
 import { elementCount } from '../helpers/elementUtils';
 
+const Timeouts = {
+  Visual: 20000,
+};
+
 test.describe('Account page tests', () => {
   let accountPage: MyAccountPage;
   test.beforeEach(async ({ page, baseURL }) => {
@@ -112,7 +116,7 @@ test.describe('Account page tests', () => {
     test('Default page appearance', async () => {
       await expect(accountPage.mainContent).toHaveScreenshot('default.png', {
         mask: [accountPage.adsWidget],
-        timeout: 20000,
+        timeout: Timeouts.Visual,
       });
     });
   });

--- a/tests/specs/pageFooter.spec.ts
+++ b/tests/specs/pageFooter.spec.ts
@@ -4,6 +4,10 @@ import BasePage from '../pages/basePage';
 import { test, expect } from '@playwright/test';
 import PageFooter from '../pages/pageFooter';
 
+const Timeouts = {
+  Visual: 20000,
+};
+
 test.describe('Page footer tests', () => {
   let pageFooter: PageFooter;
   test.beforeEach(async ({ page }) => {
@@ -40,10 +44,10 @@ test.describe('Page footer tests', () => {
   test.describe('Visual tests', () => {
     test('Default page footer appearance', async () => {
       await expect(pageFooter.footer).toHaveScreenshot('footer.png', {
-        timeout: 20000,
+        timeout: Timeouts.Visual,
       });
       await expect(pageFooter.copyrightFooter).toHaveScreenshot('copyrightFooter.png', {
-        timeout: 20000,
+        timeout: Timeouts.Visual,
       });
     });
   });

--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -4,6 +4,10 @@ import { test, expect } from '@playwright/test';
 import PageHeader from '../pages/pageHeader';
 import BasePage from '../pages/basePage';
 
+const Timeouts = {
+  Visual: 20000,
+};
+
 test.describe('Page header tests', () => {
   let pageHeader: PageHeader;
   test.beforeEach(async ({ page }) => {
@@ -46,10 +50,10 @@ test.describe('Page header tests', () => {
   test.describe('Visual tests', () => {
     test('Default page header appearance', async () => {
       await expect(pageHeader.header).toHaveScreenshot('header.png', {
-        timeout: 20000,
+        timeout: Timeouts.Visual,
       });
       await expect(pageHeader.topnav).toHaveScreenshot('topnav.png', {
-        timeout: 20000,
+        timeout: Timeouts.Visual,
       });
     });
   });

--- a/tests/specs/signInPage.spec.ts
+++ b/tests/specs/signInPage.spec.ts
@@ -5,6 +5,10 @@ import { dummyCustomer, unregisteredUser } from '../data/users';
 import { MyAccountPage } from '../pages/myAccountPage';
 import { GreetingText } from '../data/myAccountPage';
 
+const Timeouts = {
+  Visual: 20000,
+};
+
 test.describe('Sign in page tests', () => {
   let signInPage: SignInPage;
   test.beforeEach(async ({ page }) => {
@@ -120,7 +124,7 @@ test.describe('Sign in page tests', () => {
     test('Visual test', async () => {
       await expect(signInPage.mainContent).toHaveScreenshot('default.png', {
         mask: [signInPage.adsWidget],
-        timeout: 20000,
+        timeout: Timeouts.Visual,
       });
     });
   });


### PR DESCRIPTION
By adding a `Timeouts` declaration at the top of each spec file the timeouts applied to various assertions, especially the image comparisons, can be tweaked more easily when required. New values can be set per file, depending on what is required for each page, and only need to be set in one place now rather than needing to be changed for each affected test. It's a more scalable pattern for those assertions that require a longer timeout 