### PR TITLE
Refactor element count helper

### DIFF
--- a/tests/data/pageHeader.ts
+++ b/tests/data/pageHeader.ts
@@ -11,7 +11,7 @@ export const enum Colors {
   White = 'rgb(255, 255, 255)',
 }
 
-const TopnavLvl0 = {
+export const TopnavLvl0 = {
   WhatsNew: '/what-is-new.html',
   Women: '/women.html',
   Men: '/men.html',

--- a/tests/helpers/elementUtils.ts
+++ b/tests/helpers/elementUtils.ts
@@ -1,8 +1,0 @@
-import { Locator, expect } from '@playwright/test';
-
-export async function elementCount(locator: Locator, expectedCount: number): Promise<number> {
-  await expect(async () => {
-    expect(await locator.count()).toEqual(expectedCount);
-  }).toPass({ timeout: 10000 });
-  return await locator.count();
-}

--- a/tests/helpers/elementUtils.ts
+++ b/tests/helpers/elementUtils.ts
@@ -1,8 +1,8 @@
 import { Locator, expect } from '@playwright/test';
 
-export async function elementCount(locator: Locator): Promise<number> {
+export async function elementCount(locator: Locator, expectedCount: number): Promise<number> {
   await expect(async () => {
-    expect(await locator.count()).toBeGreaterThan(0);
+    expect(await locator.count()).toEqual(expectedCount);
   }).toPass({ timeout: 10000 });
   return await locator.count();
 }

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@playwright/test';
 import { HomePage, ProductItemElements } from '../pages/homePage';
 import { ExpectedText, Products, PromoBlockLinks, SwatchOutlineStyles, Colors } from '../data/homePage';
 import { rgbToHex } from '../helpers/colorUtils';
-import { elementCount } from '../helpers/elementUtils';
 
 const Timeouts = {
   ImageLink: 10000,
@@ -42,7 +41,8 @@ test.describe('Home page tests', () => {
 
     test('Text content of page elements', async () => {
       const promoBlocks = homePage.promoBlock;
-      for (let i = 0; i < (await elementCount(promoBlocks, ExpectedText.PromoBlocks.length)); i++) {
+      expect(await promoBlocks.count()).toEqual(ExpectedText.PromoBlocks.length);
+      for (let i = 0; i < (await promoBlocks.count()); i++) {
         await expect.soft(promoBlocks.nth(i)).toHaveText(ExpectedText.PromoBlocks[i]);
       }
       await expect.soft(homePage.contentHeading).toHaveText(ExpectedText.ContentHeading);
@@ -50,7 +50,8 @@ test.describe('Home page tests', () => {
 
     test('Product item details', async () => {
       const productItems = homePage.productItem;
-      for (let i = 0; i < (await elementCount(productItems, Products.length)); i++) {
+      expect(await productItems.count()).toEqual(Products.length);
+      for (let i = 0; i < (await productItems.count()); i++) {
         await expect.soft(homePage.getProductItemElement(i, ProductItemElements.Name)).toHaveText(Products[i].title);
         if (Products[i].rating) {
           await expect
@@ -65,13 +66,15 @@ test.describe('Home page tests', () => {
         await expect.soft(homePage.getProductItemElement(i, ProductItemElements.Price)).toHaveText(Products[i].price);
         if (Products[i].sizes) {
           const sizes = homePage.getProductItemElement(i, ProductItemElements.Sizes);
-          for (let j = 0; j < (await elementCount(sizes, Products[i].sizes!.length)); j++) {
+          expect(await sizes.count()).toEqual(Products[i].sizes!.length);
+          for (let j = 0; j < (await sizes.count()); j++) {
             await expect.soft(sizes.nth(j)).toHaveText(Products[i].sizes![j]);
           }
         }
         if (Products[i].colors) {
           const colors = homePage.getProductItemElement(i, ProductItemElements.Colors);
-          for (let j = 0; j < (await elementCount(colors, Products[i].colors!.length)); j++) {
+          expect(await colors.count()).toEqual(Products[i].colors!.length);
+          for (let j = 0; j < (await colors.count()); j++) {
             await expect.soft(colors.nth(j)).toHaveCSS('background-color', Products[i].colors![j]);
           }
         }
@@ -128,10 +131,11 @@ test.describe('Home page tests', () => {
     test('Can only select single size option at a time', async () => {
       // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
       const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-      for (let i = 0; i < (await elementCount(sizes, Products[0].sizes!.length)); i++) {
+      expect(await sizes.count()).toEqual(Products[0].sizes!.length);
+      for (let i = 0; i < (await sizes.count()); i++) {
         await sizes.nth(i).click();
         await expect.soft(sizes.nth(i)).toHaveClass(swatchSelectedClass);
-        for (let j = 0; j < (await elementCount(sizes, Products[0].sizes!.length)); j++) {
+        for (let j = 0; j < (await sizes.count()); j++) {
           if (j !== i) {
             await expect.soft(sizes.nth(j)).not.toHaveClass(swatchSelectedClass);
           }
@@ -142,10 +146,11 @@ test.describe('Home page tests', () => {
     test('Can only select single color option at a time', async () => {
       // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
       const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-      for (let i = 0; i < (await elementCount(colors, Products[0].colors!.length)); i++) {
+      expect(await colors.count()).toEqual(Products[0].colors!.length);
+      for (let i = 0; i < (await colors.count()); i++) {
         await colors.nth(i).click();
         await expect.soft(colors.nth(i)).toHaveClass(swatchSelectedClass);
-        for (let j = 0; j < (await elementCount(colors, Products[0].colors!.length)); j++) {
+        for (let j = 0; j < (await colors.count()); j++) {
           if (j !== i) {
             await expect.soft(colors.nth(j)).not.toHaveClass(swatchSelectedClass);
           }
@@ -177,14 +182,16 @@ test.describe('Home page tests', () => {
 
     test('Promo block links', async ({ baseURL }) => {
       const promoBlocks = homePage.promoBlock;
-      for (let i = 0; i < (await elementCount(promoBlocks, PromoBlockLinks.length)); i++) {
+      expect(await promoBlocks.count()).toEqual(PromoBlockLinks.length);
+      for (let i = 0; i < (await promoBlocks.count()); i++) {
         await expect.soft(promoBlocks.nth(i)).toHaveAttribute('href', `${baseURL}${PromoBlockLinks[i]}`);
       }
     });
 
     test('Product links', async ({ baseURL }) => {
       const products = homePage.productItem;
-      for (let i = 0; i < (await elementCount(products, Products.length)); i++) {
+      expect(await products.count()).toEqual(Products.length);
+      for (let i = 0; i < (await products.count()); i++) {
         await expect
           .soft(homePage.getProductItemElement(i, ProductItemElements.PhotoLink))
           .toHaveAttribute('href', `${baseURL}${Products[i].link}`);
@@ -203,7 +210,8 @@ test.describe('Home page tests', () => {
 
     test('Default product image links', async ({ baseURL }) => {
       const products = homePage.productItem;
-      for (let i = 0; i < (await elementCount(products, Products.length)); i++) {
+      expect(await products.count()).toEqual(Products.length);
+      for (let i = 0; i < (await products.count()); i++) {
         const imageLink = `${baseURL}${mediaDir}${Products[i].images.default}`;
         await expect
           .soft(homePage.getProductItemElement(i, ProductItemElements.Photo))
@@ -213,10 +221,12 @@ test.describe('Home page tests', () => {
 
     test('Product image links for all size options', async ({ baseURL }) => {
       const products = homePage.productItem;
-      for (let i = 0; i < (await elementCount(products, Products.length)); i++) {
+      expect(await products.count()).toEqual(Products.length);
+      for (let i = 0; i < (await products.count()); i++) {
         if (Products[i].sizes) {
           const sizes = homePage.getProductItemElement(i, ProductItemElements.Sizes);
-          for (let j = 0; j < (await elementCount(sizes, Products[i].sizes!.length)); j++) {
+          expect(await sizes.count()).toEqual(Products[i].sizes!.length);
+          for (let j = 0; j < (await sizes.count()); j++) {
             await sizes.nth(j).click();
             const imageLink = Array.isArray(Products[i].images.sizes)
               ? `${baseURL}${mediaDir}${Products[i].images.sizes[j]}`
@@ -231,10 +241,12 @@ test.describe('Home page tests', () => {
 
     test('Product image links for different color options', async ({ baseURL }) => {
       const products = homePage.productItem;
-      for (let i = 0; i < (await elementCount(products, Products.length)); i++) {
+      expect(await products.count()).toEqual(Products.length);
+      for (let i = 0; i < (await products.count()); i++) {
         if (Products[i].colors) {
           const colors = homePage.getProductItemElement(i, ProductItemElements.Colors);
-          for (let j = 0; j < (await elementCount(colors, Products[i].colors!.length)); j++) {
+          expect(await colors.count()).toEqual(Products[i].colors!.length);
+          for (let j = 0; j < (await colors.count()); j++) {
             await colors.nth(j).click();
             const imageLink = `${baseURL}${mediaDir}${Products[i].images.colors[j]}`;
             await expect
@@ -251,7 +263,8 @@ test.describe('Home page tests', () => {
     const tooltipHeight = '90';
     test('Size option tooltips', async () => {
       const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-      for (let i = 0; i < (await elementCount(sizes, Products[0].sizes!.length)); i++) {
+      expect(await sizes.count()).toEqual(Products[0].sizes!.length);
+      for (let i = 0; i < (await sizes.count()); i++) {
         await expect.soft(sizes.nth(i)).toHaveAttribute('option-tooltip-value', Products[0].sizes![i]);
         await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
         await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-height', tooltipHeight);
@@ -260,7 +273,8 @@ test.describe('Home page tests', () => {
 
     test('Color swatch tooltips', async () => {
       const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-      for (let i = 0; i < (await elementCount(colors, Products[0].colors!.length)); i++) {
+      expect(await colors.count()).toEqual(Products[0].colors!.length);
+      for (let i = 0; i < (await colors.count()); i++) {
         await expect.soft(colors.nth(i)).toHaveAttribute('option-tooltip-value', rgbToHex(Products[0].colors![i]));
         await expect.soft(colors.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
         await expect.soft(colors.nth(i)).toHaveAttribute('thumb-height', tooltipHeight);

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -41,7 +41,7 @@ test.describe('Home page tests', () => {
 
     test('Text content of page elements', async () => {
       const promoBlocks = homePage.promoBlock;
-      expect(await promoBlocks.count()).toEqual(ExpectedText.PromoBlocks.length);
+      expect.soft(await promoBlocks.count()).toEqual(ExpectedText.PromoBlocks.length);
       for (let i = 0; i < (await promoBlocks.count()); i++) {
         await expect.soft(promoBlocks.nth(i)).toHaveText(ExpectedText.PromoBlocks[i]);
       }
@@ -50,7 +50,7 @@ test.describe('Home page tests', () => {
 
     test('Product item details', async () => {
       const productItems = homePage.productItem;
-      expect(await productItems.count()).toEqual(Products.length);
+      expect.soft(await productItems.count()).toEqual(Products.length);
       for (let i = 0; i < (await productItems.count()); i++) {
         await expect.soft(homePage.getProductItemElement(i, ProductItemElements.Name)).toHaveText(Products[i].title);
         if (Products[i].rating) {
@@ -66,14 +66,14 @@ test.describe('Home page tests', () => {
         await expect.soft(homePage.getProductItemElement(i, ProductItemElements.Price)).toHaveText(Products[i].price);
         if (Products[i].sizes) {
           const sizes = homePage.getProductItemElement(i, ProductItemElements.Sizes);
-          expect(await sizes.count()).toEqual(Products[i].sizes!.length);
+          expect.soft(await sizes.count()).toEqual(Products[i].sizes!.length);
           for (let j = 0; j < (await sizes.count()); j++) {
             await expect.soft(sizes.nth(j)).toHaveText(Products[i].sizes![j]);
           }
         }
         if (Products[i].colors) {
           const colors = homePage.getProductItemElement(i, ProductItemElements.Colors);
-          expect(await colors.count()).toEqual(Products[i].colors!.length);
+          expect.soft(await colors.count()).toEqual(Products[i].colors!.length);
           for (let j = 0; j < (await colors.count()); j++) {
             await expect.soft(colors.nth(j)).toHaveCSS('background-color', Products[i].colors![j]);
           }
@@ -131,7 +131,7 @@ test.describe('Home page tests', () => {
     test('Can only select single size option at a time', async () => {
       // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
       const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-      expect(await sizes.count()).toEqual(Products[0].sizes!.length);
+      expect.soft(await sizes.count()).toEqual(Products[0].sizes!.length);
       for (let i = 0; i < (await sizes.count()); i++) {
         await sizes.nth(i).click();
         await expect.soft(sizes.nth(i)).toHaveClass(swatchSelectedClass);
@@ -146,7 +146,7 @@ test.describe('Home page tests', () => {
     test('Can only select single color option at a time', async () => {
       // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
       const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-      expect(await colors.count()).toEqual(Products[0].colors!.length);
+      expect.soft(await colors.count()).toEqual(Products[0].colors!.length);
       for (let i = 0; i < (await colors.count()); i++) {
         await colors.nth(i).click();
         await expect.soft(colors.nth(i)).toHaveClass(swatchSelectedClass);
@@ -182,7 +182,7 @@ test.describe('Home page tests', () => {
 
     test('Promo block links', async ({ baseURL }) => {
       const promoBlocks = homePage.promoBlock;
-      expect(await promoBlocks.count()).toEqual(PromoBlockLinks.length);
+      expect.soft(await promoBlocks.count()).toEqual(PromoBlockLinks.length);
       for (let i = 0; i < (await promoBlocks.count()); i++) {
         await expect.soft(promoBlocks.nth(i)).toHaveAttribute('href', `${baseURL}${PromoBlockLinks[i]}`);
       }
@@ -190,7 +190,7 @@ test.describe('Home page tests', () => {
 
     test('Product links', async ({ baseURL }) => {
       const products = homePage.productItem;
-      expect(await products.count()).toEqual(Products.length);
+      expect.soft(await products.count()).toEqual(Products.length);
       for (let i = 0; i < (await products.count()); i++) {
         await expect
           .soft(homePage.getProductItemElement(i, ProductItemElements.PhotoLink))
@@ -210,7 +210,7 @@ test.describe('Home page tests', () => {
 
     test('Default product image links', async ({ baseURL }) => {
       const products = homePage.productItem;
-      expect(await products.count()).toEqual(Products.length);
+      expect.soft(await products.count()).toEqual(Products.length);
       for (let i = 0; i < (await products.count()); i++) {
         const imageLink = `${baseURL}${mediaDir}${Products[i].images.default}`;
         await expect
@@ -221,11 +221,11 @@ test.describe('Home page tests', () => {
 
     test('Product image links for all size options', async ({ baseURL }) => {
       const products = homePage.productItem;
-      expect(await products.count()).toEqual(Products.length);
+      expect.soft(await products.count()).toEqual(Products.length);
       for (let i = 0; i < (await products.count()); i++) {
         if (Products[i].sizes) {
           const sizes = homePage.getProductItemElement(i, ProductItemElements.Sizes);
-          expect(await sizes.count()).toEqual(Products[i].sizes!.length);
+          expect.soft(await sizes.count()).toEqual(Products[i].sizes!.length);
           for (let j = 0; j < (await sizes.count()); j++) {
             await sizes.nth(j).click();
             const imageLink = Array.isArray(Products[i].images.sizes)
@@ -241,11 +241,11 @@ test.describe('Home page tests', () => {
 
     test('Product image links for different color options', async ({ baseURL }) => {
       const products = homePage.productItem;
-      expect(await products.count()).toEqual(Products.length);
+      expect.soft(await products.count()).toEqual(Products.length);
       for (let i = 0; i < (await products.count()); i++) {
         if (Products[i].colors) {
           const colors = homePage.getProductItemElement(i, ProductItemElements.Colors);
-          expect(await colors.count()).toEqual(Products[i].colors!.length);
+          expect.soft(await colors.count()).toEqual(Products[i].colors!.length);
           for (let j = 0; j < (await colors.count()); j++) {
             await colors.nth(j).click();
             const imageLink = `${baseURL}${mediaDir}${Products[i].images.colors[j]}`;
@@ -263,7 +263,7 @@ test.describe('Home page tests', () => {
     const tooltipHeight = '90';
     test('Size option tooltips', async () => {
       const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-      expect(await sizes.count()).toEqual(Products[0].sizes!.length);
+      expect.soft(await sizes.count()).toEqual(Products[0].sizes!.length);
       for (let i = 0; i < (await sizes.count()); i++) {
         await expect.soft(sizes.nth(i)).toHaveAttribute('option-tooltip-value', Products[0].sizes![i]);
         await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
@@ -273,7 +273,7 @@ test.describe('Home page tests', () => {
 
     test('Color swatch tooltips', async () => {
       const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-      expect(await colors.count()).toEqual(Products[0].colors!.length);
+      expect.soft(await colors.count()).toEqual(Products[0].colors!.length);
       for (let i = 0; i < (await colors.count()); i++) {
         await expect.soft(colors.nth(i)).toHaveAttribute('option-tooltip-value', rgbToHex(Products[0].colors![i]));
         await expect.soft(colors.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -42,7 +42,7 @@ test.describe('Home page tests', () => {
 
     test('Text content of page elements', async () => {
       const promoBlocks = homePage.promoBlock;
-      for (let i = 0; i < (await elementCount(promoBlocks)); i++) {
+      for (let i = 0; i < (await elementCount(promoBlocks, ExpectedText.PromoBlocks.length)); i++) {
         await expect.soft(promoBlocks.nth(i)).toHaveText(ExpectedText.PromoBlocks[i]);
       }
       await expect.soft(homePage.contentHeading).toHaveText(ExpectedText.ContentHeading);
@@ -50,7 +50,7 @@ test.describe('Home page tests', () => {
 
     test('Product item details', async () => {
       const productItems = homePage.productItem;
-      for (let i = 0; i < (await elementCount(productItems)); i++) {
+      for (let i = 0; i < (await elementCount(productItems, Products.length)); i++) {
         await expect.soft(homePage.getProductItemElement(i, ProductItemElements.Name)).toHaveText(Products[i].title);
         if (Products[i].rating) {
           await expect
@@ -65,13 +65,13 @@ test.describe('Home page tests', () => {
         await expect.soft(homePage.getProductItemElement(i, ProductItemElements.Price)).toHaveText(Products[i].price);
         if (Products[i].sizes) {
           const sizes = homePage.getProductItemElement(i, ProductItemElements.Sizes);
-          for (let j = 0; j < (await elementCount(sizes)); j++) {
+          for (let j = 0; j < (await elementCount(sizes, Products[i].sizes!.length)); j++) {
             await expect.soft(sizes.nth(j)).toHaveText(Products[i].sizes![j]);
           }
         }
         if (Products[i].colors) {
           const colors = homePage.getProductItemElement(i, ProductItemElements.Colors);
-          for (let j = 0; j < (await elementCount(colors)); j++) {
+          for (let j = 0; j < (await elementCount(colors, Products[i].colors!.length)); j++) {
             await expect.soft(colors.nth(j)).toHaveCSS('background-color', Products[i].colors![j]);
           }
         }
@@ -128,10 +128,10 @@ test.describe('Home page tests', () => {
     test('Can only select single size option at a time', async () => {
       // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
       const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-      for (let i = 0; i < (await elementCount(sizes)); i++) {
+      for (let i = 0; i < (await elementCount(sizes, Products[0].sizes!.length)); i++) {
         await sizes.nth(i).click();
         await expect.soft(sizes.nth(i)).toHaveClass(swatchSelectedClass);
-        for (let j = 0; j < (await elementCount(sizes)); j++) {
+        for (let j = 0; j < (await elementCount(sizes, Products[0].sizes!.length)); j++) {
           if (j !== i) {
             await expect.soft(sizes.nth(j)).not.toHaveClass(swatchSelectedClass);
           }
@@ -142,10 +142,10 @@ test.describe('Home page tests', () => {
     test('Can only select single color option at a time', async () => {
       // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
       const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-      for (let i = 0; i < (await elementCount(colors)); i++) {
+      for (let i = 0; i < (await elementCount(colors, Products[0].colors!.length)); i++) {
         await colors.nth(i).click();
         await expect.soft(colors.nth(i)).toHaveClass(swatchSelectedClass);
-        for (let j = 0; j < (await elementCount(colors)); j++) {
+        for (let j = 0; j < (await elementCount(colors, Products[0].colors!.length)); j++) {
           if (j !== i) {
             await expect.soft(colors.nth(j)).not.toHaveClass(swatchSelectedClass);
           }
@@ -177,14 +177,14 @@ test.describe('Home page tests', () => {
 
     test('Promo block links', async ({ baseURL }) => {
       const promoBlocks = homePage.promoBlock;
-      for (let i = 0; i < (await elementCount(promoBlocks)); i++) {
+      for (let i = 0; i < (await elementCount(promoBlocks, PromoBlockLinks.length)); i++) {
         await expect.soft(promoBlocks.nth(i)).toHaveAttribute('href', `${baseURL}${PromoBlockLinks[i]}`);
       }
     });
 
     test('Product links', async ({ baseURL }) => {
       const products = homePage.productItem;
-      for (let i = 0; i < (await elementCount(products)); i++) {
+      for (let i = 0; i < (await elementCount(products, Products.length)); i++) {
         await expect
           .soft(homePage.getProductItemElement(i, ProductItemElements.PhotoLink))
           .toHaveAttribute('href', `${baseURL}${Products[i].link}`);
@@ -203,7 +203,7 @@ test.describe('Home page tests', () => {
 
     test('Default product image links', async ({ baseURL }) => {
       const products = homePage.productItem;
-      for (let i = 0; i < (await elementCount(products)); i++) {
+      for (let i = 0; i < (await elementCount(products, Products.length)); i++) {
         const imageLink = `${baseURL}${mediaDir}${Products[i].images.default}`;
         await expect
           .soft(homePage.getProductItemElement(i, ProductItemElements.Photo))
@@ -213,10 +213,10 @@ test.describe('Home page tests', () => {
 
     test('Product image links for all size options', async ({ baseURL }) => {
       const products = homePage.productItem;
-      for (let i = 0; i < (await elementCount(products)); i++) {
+      for (let i = 0; i < (await elementCount(products, Products.length)); i++) {
         if (Products[i].sizes) {
           const sizes = homePage.getProductItemElement(i, ProductItemElements.Sizes);
-          for (let j = 0; j < (await elementCount(sizes)); j++) {
+          for (let j = 0; j < (await elementCount(sizes, Products[i].sizes!.length)); j++) {
             await sizes.nth(j).click();
             const imageLink = Array.isArray(Products[i].images.sizes)
               ? `${baseURL}${mediaDir}${Products[i].images.sizes[j]}`
@@ -231,10 +231,10 @@ test.describe('Home page tests', () => {
 
     test('Product image links for different color options', async ({ baseURL }) => {
       const products = homePage.productItem;
-      for (let i = 0; i < (await elementCount(products)); i++) {
+      for (let i = 0; i < (await elementCount(products, Products.length)); i++) {
         if (Products[i].colors) {
           const colors = homePage.getProductItemElement(i, ProductItemElements.Colors);
-          for (let j = 0; j < (await elementCount(colors)); j++) {
+          for (let j = 0; j < (await elementCount(colors, Products[i].colors!.length)); j++) {
             await colors.nth(j).click();
             const imageLink = `${baseURL}${mediaDir}${Products[i].images.colors[j]}`;
             await expect
@@ -251,7 +251,7 @@ test.describe('Home page tests', () => {
     const tooltipHeight = '90';
     test('Size option tooltips', async () => {
       const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-      for (let i = 0; i < (await elementCount(sizes)); i++) {
+      for (let i = 0; i < (await elementCount(sizes, Products[0].sizes!.length)); i++) {
         await expect.soft(sizes.nth(i)).toHaveAttribute('option-tooltip-value', Products[0].sizes![i]);
         await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
         await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-height', tooltipHeight);
@@ -260,7 +260,7 @@ test.describe('Home page tests', () => {
 
     test('Color swatch tooltips', async () => {
       const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-      for (let i = 0; i < (await elementCount(colors)); i++) {
+      for (let i = 0; i < (await elementCount(colors, Products[0].colors!.length)); i++) {
         await expect.soft(colors.nth(i)).toHaveAttribute('option-tooltip-value', rgbToHex(Products[0].colors![i]));
         await expect.soft(colors.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
         await expect.soft(colors.nth(i)).toHaveAttribute('thumb-height', tooltipHeight);

--- a/tests/specs/myAccountPage.spec.ts
+++ b/tests/specs/myAccountPage.spec.ts
@@ -52,13 +52,13 @@ test.describe('Account page tests', () => {
         .soft(accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Content))
         .toHaveText(`${dummyCustomer.name}\n${dummyCustomer.email}`);
       let actions = accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Actions);
-      expect(await actions.count()).toEqual(ExpectedText.AccountInfo.ContactInfo.Actions.length);
+      expect.soft(await actions.count()).toEqual(ExpectedText.AccountInfo.ContactInfo.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AccountInfo.ContactInfo.Actions[i]);
       }
       await expect.soft(accountPage.addressBookTitle).toHaveText(ExpectedText.AddressBook.Title);
       actions = accountPage.addressBookActions;
-      expect(await actions.count()).toEqual(ExpectedText.AddressBook.Actions.length);
+      expect.soft(await actions.count()).toEqual(ExpectedText.AddressBook.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.Actions[i]);
       }
@@ -69,7 +69,7 @@ test.describe('Account page tests', () => {
         .soft(accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.BillingAddress.Placeholder);
       actions = accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Actions);
-      expect(await actions.count()).toEqual(ExpectedText.AddressBook.BillingAddress.Actions.length);
+      expect.soft(await actions.count()).toEqual(ExpectedText.AddressBook.BillingAddress.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.BillingAddress.Actions[i]);
       }
@@ -80,12 +80,12 @@ test.describe('Account page tests', () => {
         .soft(accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.ShippingAddress.Placeholder);
       actions = accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Actions);
-      expect(await actions.count()).toEqual(ExpectedText.AddressBook.ShippingAddress.Actions.length);
+      expect.soft(await actions.count()).toEqual(ExpectedText.AddressBook.ShippingAddress.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.ShippingAddress.Actions[i]);
       }
       const sidenavOptions = accountPage.sidenavOption;
-      expect(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
+      expect.soft(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
       for (let i = 0; i < (await sidenavOptions.count()); i++) {
         await expect.soft(sidenavOptions.nth(i)).toHaveText(ExpectedText.PrimarySidenav[i]);
       }
@@ -104,7 +104,7 @@ test.describe('Account page tests', () => {
     test('My Account sidenav option selected by default', async () => {
       const selectedClass = /current/;
       const sidenavOptions = accountPage.sidenavOption;
-      expect(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
+      expect.soft(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
       await expect(sidenavOptions.first()).toHaveClass(selectedClass);
       for (let i = 1; i < (await sidenavOptions.count()); i++) {
         await expect.soft(sidenavOptions.nth(i)).not.toHaveClass(selectedClass);
@@ -129,7 +129,7 @@ test.describe('Account page tests', () => {
   test.describe('Link tests', () => {
     test('Sidenav links', async ({ baseURL }) => {
       const sidenavLinks = accountPage.sidenavLink;
-      expect(await sidenavLinks.count()).toEqual(Links.Sidenav.length);
+      expect.soft(await sidenavLinks.count()).toEqual(Links.Sidenav.length);
       for (let i = 0; i < (await sidenavLinks.count()); i++) {
         await expect.soft(sidenavLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Sidenav[i]}`);
       }
@@ -137,7 +137,7 @@ test.describe('Account page tests', () => {
 
     test('Account info links', async ({ baseURL }) => {
       const actionLinks = accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Actions);
-      expect(await actionLinks.count()).toEqual(Links.ContactInfoActions.length);
+      expect.soft(await actionLinks.count()).toEqual(Links.ContactInfoActions.length);
       for (let i = 0; i < (await actionLinks.count()); i++) {
         await expect.soft(actionLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.ContactInfoActions[i]}`);
       }

--- a/tests/specs/myAccountPage.spec.ts
+++ b/tests/specs/myAccountPage.spec.ts
@@ -3,7 +3,6 @@ import { MyAccountPage, BlockElements } from '../pages/myAccountPage';
 import { Colors, ExpectedText, Links } from '../data/myAccountPage';
 import SignInPage from '../pages/signInPage';
 import { dummyCustomer } from '../data/users';
-import { elementCount } from '../helpers/elementUtils';
 
 const Timeouts = {
   Visual: 20000,
@@ -53,12 +52,14 @@ test.describe('Account page tests', () => {
         .soft(accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Content))
         .toHaveText(`${dummyCustomer.name}\n${dummyCustomer.email}`);
       let actions = accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Actions);
-      for (let i = 0; i < (await elementCount(actions, ExpectedText.AccountInfo.ContactInfo.Actions.length)); i++) {
+      expect(await actions.count()).toEqual(ExpectedText.AccountInfo.ContactInfo.Actions.length);
+      for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AccountInfo.ContactInfo.Actions[i]);
       }
       await expect.soft(accountPage.addressBookTitle).toHaveText(ExpectedText.AddressBook.Title);
       actions = accountPage.addressBookActions;
-      for (let i = 0; i < (await elementCount(actions, ExpectedText.AddressBook.Actions.length)); i++) {
+      expect(await actions.count()).toEqual(ExpectedText.AddressBook.Actions.length);
+      for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.Actions[i]);
       }
       await expect
@@ -68,7 +69,8 @@ test.describe('Account page tests', () => {
         .soft(accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.BillingAddress.Placeholder);
       actions = accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Actions);
-      for (let i = 0; i < (await elementCount(actions, ExpectedText.AddressBook.BillingAddress.Actions.length)); i++) {
+      expect(await actions.count()).toEqual(ExpectedText.AddressBook.BillingAddress.Actions.length);
+      for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.BillingAddress.Actions[i]);
       }
       await expect
@@ -78,11 +80,13 @@ test.describe('Account page tests', () => {
         .soft(accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.ShippingAddress.Placeholder);
       actions = accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Actions);
-      for (let i = 0; i < (await elementCount(actions, ExpectedText.AddressBook.ShippingAddress.Actions.length)); i++) {
+      expect(await actions.count()).toEqual(ExpectedText.AddressBook.ShippingAddress.Actions.length);
+      for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.ShippingAddress.Actions[i]);
       }
       const sidenavOptions = accountPage.sidenavOption;
-      for (let i = 0; i < (await elementCount(sidenavOptions, ExpectedText.PrimarySidenav.length)); i++) {
+      expect(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
+      for (let i = 0; i < (await sidenavOptions.count()); i++) {
         await expect.soft(sidenavOptions.nth(i)).toHaveText(ExpectedText.PrimarySidenav[i]);
       }
       await expect
@@ -100,8 +104,9 @@ test.describe('Account page tests', () => {
     test('My Account sidenav option selected by default', async () => {
       const selectedClass = /current/;
       const sidenavOptions = accountPage.sidenavOption;
+      expect(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
       await expect(sidenavOptions.first()).toHaveClass(selectedClass);
-      for (let i = 1; i < (await elementCount(sidenavOptions, ExpectedText.PrimarySidenav.length)); i++) {
+      for (let i = 1; i < (await sidenavOptions.count()); i++) {
         await expect.soft(sidenavOptions.nth(i)).not.toHaveClass(selectedClass);
       }
     });
@@ -124,14 +129,16 @@ test.describe('Account page tests', () => {
   test.describe('Link tests', () => {
     test('Sidenav links', async ({ baseURL }) => {
       const sidenavLinks = accountPage.sidenavLink;
-      for (let i = 0; i < (await elementCount(sidenavLinks, Links.Sidenav.length)); i++) {
+      expect(await sidenavLinks.count()).toEqual(Links.Sidenav.length);
+      for (let i = 0; i < (await sidenavLinks.count()); i++) {
         await expect.soft(sidenavLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Sidenav[i]}`);
       }
     });
 
     test('Account info links', async ({ baseURL }) => {
       const actionLinks = accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Actions);
-      for (let i = 0; i < (await elementCount(actionLinks, Links.ContactInfoActions.length)); i++) {
+      expect(await actionLinks.count()).toEqual(Links.ContactInfoActions.length);
+      for (let i = 0; i < (await actionLinks.count()); i++) {
         await expect.soft(actionLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.ContactInfoActions[i]}`);
       }
     });

--- a/tests/specs/myAccountPage.spec.ts
+++ b/tests/specs/myAccountPage.spec.ts
@@ -53,12 +53,12 @@ test.describe('Account page tests', () => {
         .soft(accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Content))
         .toHaveText(`${dummyCustomer.name}\n${dummyCustomer.email}`);
       let actions = accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Actions);
-      for (let i = 0; i < (await elementCount(actions)); i++) {
+      for (let i = 0; i < (await elementCount(actions, ExpectedText.AccountInfo.ContactInfo.Actions.length)); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AccountInfo.ContactInfo.Actions[i]);
       }
       await expect.soft(accountPage.addressBookTitle).toHaveText(ExpectedText.AddressBook.Title);
       actions = accountPage.addressBookActions;
-      for (let i = 0; i < (await elementCount(actions)); i++) {
+      for (let i = 0; i < (await elementCount(actions, ExpectedText.AddressBook.Actions.length)); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.Actions[i]);
       }
       await expect
@@ -68,7 +68,7 @@ test.describe('Account page tests', () => {
         .soft(accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.BillingAddress.Placeholder);
       actions = accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Actions);
-      for (let i = 0; i < (await elementCount(actions)); i++) {
+      for (let i = 0; i < (await elementCount(actions, ExpectedText.AddressBook.BillingAddress.Actions.length)); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.BillingAddress.Actions[i]);
       }
       await expect
@@ -78,11 +78,11 @@ test.describe('Account page tests', () => {
         .soft(accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.ShippingAddress.Placeholder);
       actions = accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Actions);
-      for (let i = 0; i < (await elementCount(actions)); i++) {
+      for (let i = 0; i < (await elementCount(actions, ExpectedText.AddressBook.ShippingAddress.Actions.length)); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.ShippingAddress.Actions[i]);
       }
       const sidenavOptions = accountPage.sidenavOption;
-      for (let i = 0; i < (await elementCount(sidenavOptions)); i++) {
+      for (let i = 0; i < (await elementCount(sidenavOptions, ExpectedText.PrimarySidenav.length)); i++) {
         await expect.soft(sidenavOptions.nth(i)).toHaveText(ExpectedText.PrimarySidenav[i]);
       }
       await expect
@@ -101,7 +101,7 @@ test.describe('Account page tests', () => {
       const selectedClass = /current/;
       const sidenavOptions = accountPage.sidenavOption;
       await expect(sidenavOptions.first()).toHaveClass(selectedClass);
-      for (let i = 1; i < (await elementCount(sidenavOptions)); i++) {
+      for (let i = 1; i < (await elementCount(sidenavOptions, ExpectedText.PrimarySidenav.length)); i++) {
         await expect.soft(sidenavOptions.nth(i)).not.toHaveClass(selectedClass);
       }
     });
@@ -124,14 +124,14 @@ test.describe('Account page tests', () => {
   test.describe('Link tests', () => {
     test('Sidenav links', async ({ baseURL }) => {
       const sidenavLinks = accountPage.sidenavLink;
-      for (let i = 0; i < (await elementCount(sidenavLinks)); i++) {
+      for (let i = 0; i < (await elementCount(sidenavLinks, Links.Sidenav.length)); i++) {
         await expect.soft(sidenavLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Sidenav[i]}`);
       }
     });
 
     test('Account info links', async ({ baseURL }) => {
       const actionLinks = accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Actions);
-      for (let i = 0; i < (await elementCount(actionLinks)); i++) {
+      for (let i = 0; i < (await elementCount(actionLinks, Links.ContactInfoActions.length)); i++) {
         await expect.soft(actionLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.ContactInfoActions[i]}`);
       }
     });

--- a/tests/specs/pageFooter.spec.ts
+++ b/tests/specs/pageFooter.spec.ts
@@ -34,7 +34,7 @@ test.describe('Page footer tests', () => {
 
     test('Text content of page elements', async () => {
       const footerLinks = pageFooter.footerLink;
-      for (let i = 0; i < (await elementCount(footerLinks)); i++) {
+      for (let i = 0; i < (await elementCount(footerLinks, ExpectedText.FooterLinks.length)); i++) {
         await expect.soft(footerLinks.nth(i)).toHaveText(ExpectedText.FooterLinks[i]);
       }
       await expect.soft(pageFooter.copyrightFooter).toHaveText(ExpectedText.Copyright);
@@ -55,7 +55,7 @@ test.describe('Page footer tests', () => {
   test.describe('Link tests', () => {
     test('Footer links', async ({ baseURL }) => {
       const footerLinks = pageFooter.footerLink;
-      for (let i = 0; i < (await elementCount(footerLinks)); i++) {
+      for (let i = 0; i < (await elementCount(footerLinks, FooterLinks.length)); i++) {
         const expectedLink = FooterLinks[i].startsWith('https') ? FooterLinks[i] : `${baseURL}${FooterLinks[i]}`;
         await expect.soft(footerLinks.nth(i)).toHaveAttribute('href', expectedLink);
       }

--- a/tests/specs/pageFooter.spec.ts
+++ b/tests/specs/pageFooter.spec.ts
@@ -1,5 +1,4 @@
 import { ExpectedText, Colors, FooterLinks } from '../data/pageFooter';
-import { elementCount } from '../helpers/elementUtils';
 import BasePage from '../pages/basePage';
 import { test, expect } from '@playwright/test';
 import PageFooter from '../pages/pageFooter';
@@ -34,7 +33,8 @@ test.describe('Page footer tests', () => {
 
     test('Text content of page elements', async () => {
       const footerLinks = pageFooter.footerLink;
-      for (let i = 0; i < (await elementCount(footerLinks, ExpectedText.FooterLinks.length)); i++) {
+      expect(await footerLinks.count()).toEqual(ExpectedText.FooterLinks.length);
+      for (let i = 0; i < (await footerLinks.count()); i++) {
         await expect.soft(footerLinks.nth(i)).toHaveText(ExpectedText.FooterLinks[i]);
       }
       await expect.soft(pageFooter.copyrightFooter).toHaveText(ExpectedText.Copyright);
@@ -55,7 +55,8 @@ test.describe('Page footer tests', () => {
   test.describe('Link tests', () => {
     test('Footer links', async ({ baseURL }) => {
       const footerLinks = pageFooter.footerLink;
-      for (let i = 0; i < (await elementCount(footerLinks, FooterLinks.length)); i++) {
+      expect(await footerLinks.count()).toEqual(FooterLinks.length);
+      for (let i = 0; i < (await footerLinks.count()); i++) {
         const expectedLink = FooterLinks[i].startsWith('https') ? FooterLinks[i] : `${baseURL}${FooterLinks[i]}`;
         await expect.soft(footerLinks.nth(i)).toHaveAttribute('href', expectedLink);
       }

--- a/tests/specs/pageFooter.spec.ts
+++ b/tests/specs/pageFooter.spec.ts
@@ -33,7 +33,7 @@ test.describe('Page footer tests', () => {
 
     test('Text content of page elements', async () => {
       const footerLinks = pageFooter.footerLink;
-      expect(await footerLinks.count()).toEqual(ExpectedText.FooterLinks.length);
+      expect.soft(await footerLinks.count()).toEqual(ExpectedText.FooterLinks.length);
       for (let i = 0; i < (await footerLinks.count()); i++) {
         await expect.soft(footerLinks.nth(i)).toHaveText(ExpectedText.FooterLinks[i]);
       }
@@ -55,7 +55,7 @@ test.describe('Page footer tests', () => {
   test.describe('Link tests', () => {
     test('Footer links', async ({ baseURL }) => {
       const footerLinks = pageFooter.footerLink;
-      expect(await footerLinks.count()).toEqual(FooterLinks.length);
+      expect.soft(await footerLinks.count()).toEqual(FooterLinks.length);
       for (let i = 0; i < (await footerLinks.count()); i++) {
         const expectedLink = FooterLinks[i].startsWith('https') ? FooterLinks[i] : `${baseURL}${FooterLinks[i]}`;
         await expect.soft(footerLinks.nth(i)).toHaveAttribute('href', expectedLink);

--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -40,7 +40,7 @@ test.describe('Page header tests', () => {
       await expect.soft(pageHeader.searchInput).toBeEmpty();
       await expect.soft(pageHeader.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
       const topnavLinks = pageHeader.topnavLvl0Link;
-      expect(await topnavLinks.count()).toEqual(ExpectedText.Topnav.length);
+      expect.soft(await topnavLinks.count()).toEqual(ExpectedText.Topnav.length);
       for (let i = 0; i < (await topnavLinks.count()); i++) {
         await expect.soft(topnavLinks.nth(i)).toHaveText(ExpectedText.Topnav[i]);
       }
@@ -76,7 +76,7 @@ test.describe('Page header tests', () => {
 
     test('Topnav links', async ({ baseURL }) => {
       const lvl0Links = pageHeader.topnavLvl0Link;
-      expect(await lvl0Links.count()).toEqual(Object.keys(TopnavLvl0).length);
+      expect.soft(await lvl0Links.count()).toEqual(Object.keys(TopnavLvl0).length);
       for (let i = 0; i < (await lvl0Links.count()); i++) {
         const lvl0Text = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
         await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0Text]}`);
@@ -87,7 +87,7 @@ test.describe('Page header tests', () => {
         // would with a website under my control
         if (lvl0Text !== 'WhatsNew' && lvl0Text !== 'Sale') {
           const subMenuLinks = await pageHeader.getTopnavSubMenuLinks(i);
-          expect(await subMenuLinks.count()).toEqual(Object.keys(Links.Topnav[`${lvl0Text}SubMenu`]).length);
+          expect.soft(await subMenuLinks.count()).toEqual(Object.keys(Links.Topnav[`${lvl0Text}SubMenu`]).length);
           for (let j = 0; j < (await subMenuLinks.count()); j++) {
             const subMenuText = (await subMenuLinks.nth(j).innerText()).replace(/\W+/g, '');
             await expect

--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -1,5 +1,4 @@
 import { ExpectedText, Colors, Links, TopnavLvl0 } from '../data/pageHeader';
-import { elementCount } from '../helpers/elementUtils';
 import { test, expect } from '@playwright/test';
 import PageHeader from '../pages/pageHeader';
 import BasePage from '../pages/basePage';
@@ -41,7 +40,8 @@ test.describe('Page header tests', () => {
       await expect.soft(pageHeader.searchInput).toBeEmpty();
       await expect.soft(pageHeader.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
       const topnavLinks = pageHeader.topnavLvl0Link;
-      for (let i = 0; i < (await elementCount(topnavLinks, ExpectedText.Topnav.length)); i++) {
+      expect(await topnavLinks.count()).toEqual(ExpectedText.Topnav.length);
+      for (let i = 0; i < (await topnavLinks.count()); i++) {
         await expect.soft(topnavLinks.nth(i)).toHaveText(ExpectedText.Topnav[i]);
       }
     });
@@ -76,8 +76,8 @@ test.describe('Page header tests', () => {
 
     test('Topnav links', async ({ baseURL }) => {
       const lvl0Links = pageHeader.topnavLvl0Link;
-      const lvl0Count = Object.keys(TopnavLvl0).length;
-      for (let i = 0; i < (await elementCount(lvl0Links, lvl0Count)); i++) {
+      expect(await lvl0Links.count()).toEqual(Object.keys(TopnavLvl0).length);
+      for (let i = 0; i < (await lvl0Links.count()); i++) {
         const lvl0Text = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
         await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0Text]}`);
 
@@ -87,8 +87,8 @@ test.describe('Page header tests', () => {
         // would with a website under my control
         if (lvl0Text !== 'WhatsNew' && lvl0Text !== 'Sale') {
           const subMenuLinks = await pageHeader.getTopnavSubMenuLinks(i);
-          const subMenuCount = Object.keys(Links.Topnav[`${lvl0Text}SubMenu`]).length;
-          for (let j = 0; j < (await elementCount(subMenuLinks, subMenuCount)); j++) {
+          expect(await subMenuLinks.count()).toEqual(Object.keys(Links.Topnav[`${lvl0Text}SubMenu`]).length);
+          for (let j = 0; j < (await subMenuLinks.count()); j++) {
             const subMenuText = (await subMenuLinks.nth(j).innerText()).replace(/\W+/g, '');
             await expect
               .soft(subMenuLinks.nth(j))

--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -1,4 +1,4 @@
-import { ExpectedText, Colors, Links } from '../data/pageHeader';
+import { ExpectedText, Colors, Links, TopnavLvl0 } from '../data/pageHeader';
 import { elementCount } from '../helpers/elementUtils';
 import { test, expect } from '@playwright/test';
 import PageHeader from '../pages/pageHeader';
@@ -41,7 +41,7 @@ test.describe('Page header tests', () => {
       await expect.soft(pageHeader.searchInput).toBeEmpty();
       await expect.soft(pageHeader.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
       const topnavLinks = pageHeader.topnavLvl0Link;
-      for (let i = 0; i < (await elementCount(topnavLinks)); i++) {
+      for (let i = 0; i < (await elementCount(topnavLinks, ExpectedText.Topnav.length)); i++) {
         await expect.soft(topnavLinks.nth(i)).toHaveText(ExpectedText.Topnav[i]);
       }
     });
@@ -76,7 +76,8 @@ test.describe('Page header tests', () => {
 
     test('Topnav links', async ({ baseURL }) => {
       const lvl0Links = pageHeader.topnavLvl0Link;
-      for (let i = 0; i < (await elementCount(lvl0Links)); i++) {
+      const lvl0Count = Object.keys(TopnavLvl0).length;
+      for (let i = 0; i < (await elementCount(lvl0Links, lvl0Count)); i++) {
         const lvl0Text = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
         await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0Text]}`);
 
@@ -86,7 +87,8 @@ test.describe('Page header tests', () => {
         // would with a website under my control
         if (lvl0Text !== 'WhatsNew' && lvl0Text !== 'Sale') {
           const subMenuLinks = await pageHeader.getTopnavSubMenuLinks(i);
-          for (let j = 0; j < (await elementCount(subMenuLinks)); j++) {
+          const subMenuCount = Object.keys(Links.Topnav[`${lvl0Text}SubMenu`]).length;
+          for (let j = 0; j < (await elementCount(subMenuLinks, subMenuCount)); j++) {
             const subMenuText = (await subMenuLinks.nth(j).innerText()).replace(/\W+/g, '');
             await expect
               .soft(subMenuLinks.nth(j))


### PR DESCRIPTION
The `elementCount` helper method was used to assert that the correct number of elements has been found in the UI and was used when iterating over a number of similar elements. The method included a `toBeGreaterThan(0)` check to ensure we had at least 1 such element and I updated this to assert against an expected count before returning. However, having done so I realised the method was now redundant and the expected count assertion could be included in the test itself. I was never 100% happy with this method and it took an initial refactor for me to spot the right pattern and in doing so retire this helper method. I'm much happier with the test pattern now