### PR TITLE
Rename accountPage to myAccountPage

### DIFF
--- a/tests/specs/myAccountPage.spec.ts
+++ b/tests/specs/myAccountPage.spec.ts
@@ -8,14 +8,14 @@ const Timeouts = {
   Visual: 20000,
 };
 
-test.describe('Account page tests', () => {
-  let accountPage: MyAccountPage;
+test.describe('My Account page tests', () => {
+  let myAccountPage: MyAccountPage;
   test.beforeEach(async ({ page, baseURL }) => {
-    accountPage = new MyAccountPage(page);
+    myAccountPage = new MyAccountPage(page);
     const signinPage = new SignInPage(page);
     await signinPage.open();
     await signinPage.loginAs(dummyCustomer.email, dummyCustomer.password);
-    await expect(page).toHaveURL(`${baseURL}${accountPage.url}`);
+    await expect(page).toHaveURL(`${baseURL}${myAccountPage.url}`);
   });
 
   test.describe('Appearance tests', () => {
@@ -23,87 +23,87 @@ test.describe('Account page tests', () => {
     // The tests could be combined but I have split them here to make them easier to read and maintain
 
     test('Main page elements displayed', async () => {
-      await expect.soft(accountPage.globalMessage).toBeVisible();
-      await expect.soft(accountPage.pageHeader.header).toBeVisible();
-      await expect.soft(accountPage.pageHeader.topnav).toBeVisible();
-      await expect.soft(accountPage.mainBlock).toBeVisible();
-      await expect.soft(accountPage.primarySidenav).toBeVisible();
-      await expect.soft(accountPage.secondarySidenav).toBeVisible();
-      await expect.soft(accountPage.pageTitle).toBeVisible();
-      await expect.soft(accountPage.accountInfoBlock).toBeVisible();
-      await expect.soft(accountPage.addressBookBlock).toBeVisible();
-      await expect.soft(accountPage.pageFooter.footer).toBeVisible();
-      await expect.soft(accountPage.pageFooter.copyrightFooter).toBeVisible();
+      await expect.soft(myAccountPage.globalMessage).toBeVisible();
+      await expect.soft(myAccountPage.pageHeader.header).toBeVisible();
+      await expect.soft(myAccountPage.pageHeader.topnav).toBeVisible();
+      await expect.soft(myAccountPage.mainBlock).toBeVisible();
+      await expect.soft(myAccountPage.primarySidenav).toBeVisible();
+      await expect.soft(myAccountPage.secondarySidenav).toBeVisible();
+      await expect.soft(myAccountPage.pageTitle).toBeVisible();
+      await expect.soft(myAccountPage.accountInfoBlock).toBeVisible();
+      await expect.soft(myAccountPage.addressBookBlock).toBeVisible();
+      await expect.soft(myAccountPage.pageFooter.footer).toBeVisible();
+      await expect.soft(myAccountPage.pageFooter.copyrightFooter).toBeVisible();
     });
 
     test('Element styling', async () => {
-      await expect.soft(accountPage.mainBlock).toHaveCSS('background-color', Colors.White);
-      await expect.soft(accountPage.primarySidenav).toHaveCSS('background-color', Colors.Grey);
-      await expect.soft(accountPage.secondarySidenav).toHaveCSS('background-color', Colors.White);
+      await expect.soft(myAccountPage.mainBlock).toHaveCSS('background-color', Colors.White);
+      await expect.soft(myAccountPage.primarySidenav).toHaveCSS('background-color', Colors.Grey);
+      await expect.soft(myAccountPage.secondarySidenav).toHaveCSS('background-color', Colors.White);
     });
 
     test('Text content of page elements', async () => {
-      await expect.soft(accountPage.pageTitle).toHaveText(ExpectedText.PageTitle);
-      await expect.soft(accountPage.accountInfoTitle).toHaveText(ExpectedText.AccountInfo.Title);
+      await expect.soft(myAccountPage.pageTitle).toHaveText(ExpectedText.PageTitle);
+      await expect.soft(myAccountPage.accountInfoTitle).toHaveText(ExpectedText.AccountInfo.Title);
       await expect
-        .soft(accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Title))
+        .soft(myAccountPage.getBlockElement(myAccountPage.contactInfoBlock, BlockElements.Title))
         .toHaveText(ExpectedText.AccountInfo.ContactInfo.Title);
       await expect
-        .soft(accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Content))
+        .soft(myAccountPage.getBlockElement(myAccountPage.contactInfoBlock, BlockElements.Content))
         .toHaveText(`${dummyCustomer.name}\n${dummyCustomer.email}`);
-      let actions = accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Actions);
+      let actions = myAccountPage.getBlockElement(myAccountPage.contactInfoBlock, BlockElements.Actions);
       expect.soft(await actions.count()).toEqual(ExpectedText.AccountInfo.ContactInfo.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AccountInfo.ContactInfo.Actions[i]);
       }
-      await expect.soft(accountPage.addressBookTitle).toHaveText(ExpectedText.AddressBook.Title);
-      actions = accountPage.addressBookActions;
+      await expect.soft(myAccountPage.addressBookTitle).toHaveText(ExpectedText.AddressBook.Title);
+      actions = myAccountPage.addressBookActions;
       expect.soft(await actions.count()).toEqual(ExpectedText.AddressBook.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.Actions[i]);
       }
       await expect
-        .soft(accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Title))
+        .soft(myAccountPage.getBlockElement(myAccountPage.billingAddressBlock, BlockElements.Title))
         .toHaveText(ExpectedText.AddressBook.BillingAddress.Title);
       await expect
-        .soft(accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Content))
+        .soft(myAccountPage.getBlockElement(myAccountPage.billingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.BillingAddress.Placeholder);
-      actions = accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Actions);
+      actions = myAccountPage.getBlockElement(myAccountPage.billingAddressBlock, BlockElements.Actions);
       expect.soft(await actions.count()).toEqual(ExpectedText.AddressBook.BillingAddress.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.BillingAddress.Actions[i]);
       }
       await expect
-        .soft(accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Title))
+        .soft(myAccountPage.getBlockElement(myAccountPage.shippingAddressBlock, BlockElements.Title))
         .toHaveText(ExpectedText.AddressBook.ShippingAddress.Title);
       await expect
-        .soft(accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Content))
+        .soft(myAccountPage.getBlockElement(myAccountPage.shippingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.ShippingAddress.Placeholder);
-      actions = accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Actions);
+      actions = myAccountPage.getBlockElement(myAccountPage.shippingAddressBlock, BlockElements.Actions);
       expect.soft(await actions.count()).toEqual(ExpectedText.AddressBook.ShippingAddress.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.ShippingAddress.Actions[i]);
       }
-      const sidenavOptions = accountPage.sidenavOption;
+      const sidenavOptions = myAccountPage.sidenavOption;
       expect.soft(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
       for (let i = 0; i < (await sidenavOptions.count()); i++) {
         await expect.soft(sidenavOptions.nth(i)).toHaveText(ExpectedText.PrimarySidenav[i]);
       }
       await expect
-        .soft(accountPage.compareProductsTitle)
+        .soft(myAccountPage.compareProductsTitle)
         .toHaveText(ExpectedText.SecondarySidenav.CompareProducts.Title);
       await expect
-        .soft(accountPage.compareProductsContent)
+        .soft(myAccountPage.compareProductsContent)
         .toHaveText(ExpectedText.SecondarySidenav.CompareProducts.Placeholder, { useInnerText: true });
-      await expect.soft(accountPage.wishlistTitle).toHaveText(ExpectedText.SecondarySidenav.Wishlist.Title);
+      await expect.soft(myAccountPage.wishlistTitle).toHaveText(ExpectedText.SecondarySidenav.Wishlist.Title);
       await expect
-        .soft(accountPage.wishlistContent)
+        .soft(myAccountPage.wishlistContent)
         .toHaveText(ExpectedText.SecondarySidenav.Wishlist.Placeholder, { useInnerText: true });
     });
 
     test('My Account sidenav option selected by default', async () => {
       const selectedClass = /current/;
-      const sidenavOptions = accountPage.sidenavOption;
+      const sidenavOptions = myAccountPage.sidenavOption;
       expect.soft(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
       await expect(sidenavOptions.first()).toHaveClass(selectedClass);
       for (let i = 1; i < (await sidenavOptions.count()); i++) {
@@ -119,8 +119,8 @@ test.describe('Account page tests', () => {
 
   test.describe('Visual tests', () => {
     test('Default page appearance', async () => {
-      await expect(accountPage.mainContent).toHaveScreenshot('default.png', {
-        mask: [accountPage.adsWidget],
+      await expect(myAccountPage.mainContent).toHaveScreenshot('default.png', {
+        mask: [myAccountPage.adsWidget],
         timeout: Timeouts.Visual,
       });
     });
@@ -128,7 +128,7 @@ test.describe('Account page tests', () => {
 
   test.describe('Link tests', () => {
     test('Sidenav links', async ({ baseURL }) => {
-      const sidenavLinks = accountPage.sidenavLink;
+      const sidenavLinks = myAccountPage.sidenavLink;
       expect.soft(await sidenavLinks.count()).toEqual(Links.Sidenav.length);
       for (let i = 0; i < (await sidenavLinks.count()); i++) {
         await expect.soft(sidenavLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Sidenav[i]}`);
@@ -136,7 +136,7 @@ test.describe('Account page tests', () => {
     });
 
     test('Account info links', async ({ baseURL }) => {
-      const actionLinks = accountPage.getBlockElement(accountPage.contactInfoBlock, BlockElements.Actions);
+      const actionLinks = myAccountPage.getBlockElement(myAccountPage.contactInfoBlock, BlockElements.Actions);
       expect.soft(await actionLinks.count()).toEqual(Links.ContactInfoActions.length);
       for (let i = 0; i < (await actionLinks.count()); i++) {
         await expect.soft(actionLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.ContactInfoActions[i]}`);
@@ -145,14 +145,14 @@ test.describe('Account page tests', () => {
 
     test('Address book links', async ({ baseURL }) => {
       await expect
-        .soft(accountPage.addressBookActions)
+        .soft(myAccountPage.addressBookActions)
         .toHaveAttribute('href', `${baseURL}${Links.AddressBookActions[0]}`);
       // The "Edit Address" link for billing & shipping address is the same
       await expect
-        .soft(accountPage.getBlockElement(accountPage.billingAddressBlock, BlockElements.Actions))
+        .soft(myAccountPage.getBlockElement(myAccountPage.billingAddressBlock, BlockElements.Actions))
         .toHaveAttribute('href', `${baseURL}${Links.AddressBookActions[1]}`);
       await expect
-        .soft(accountPage.getBlockElement(accountPage.shippingAddressBlock, BlockElements.Actions))
+        .soft(myAccountPage.getBlockElement(myAccountPage.shippingAddressBlock, BlockElements.Actions))
         .toHaveAttribute('href', `${baseURL}${Links.AddressBookActions[1]}`);
     });
   });

--- a/tests/specs/signInPage.spec.ts
+++ b/tests/specs/signInPage.spec.ts
@@ -19,10 +19,10 @@ test.describe('Sign in page tests', () => {
   test.describe('Behavioural tests', () => {
     test.describe('Successful logins', () => {
       test('Login successfully', async ({ page, baseURL }) => {
-        const accountPage = new MyAccountPage(page);
+        const myAccountPage = new MyAccountPage(page);
         await signInPage.loginAs(dummyCustomer.email, dummyCustomer.password);
-        await expect(page).toHaveURL(`${baseURL}${accountPage.url}`);
-        await expect.soft(accountPage.pageHeader.greeting).toHaveText(GreetingText(dummyCustomer.name));
+        await expect(page).toHaveURL(`${baseURL}${myAccountPage.url}`);
+        await expect.soft(myAccountPage.pageHeader.greeting).toHaveText(GreetingText(dummyCustomer.name));
       });
     });
 


### PR DESCRIPTION
Somehow in previous PRs I missed renaming all instances of `accountPage` to `myAccountPage` so this PR just tidies up what was missed previously for overall consistency