### PR TITLE
Refactor product data to common module

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright browsers
-        run: npx playwright install
+        run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npm run pw:all
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,8 +16,8 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: npm ci
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+      - name: Install Playwright browsers
+        run: npx playwright install
       - name: Run Playwright tests
         run: npm run pw:all
       - uses: actions/upload-artifact@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     trace: 'retain-on-failure',
     video: 'retain-on-failure',
   },
-  timeout: 45000,
+  timeout: 60000,
   snapshotPathTemplate: 'tests/data/snapshots/{platform}{/projectName}/{testFilePath}/{arg}{ext}',
   projects: [
     {
@@ -27,7 +27,7 @@ export default defineConfig({
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
-      timeout: 90000
+      timeout: 90000,
     },
   ],
 });

--- a/tests/data/homePage.ts
+++ b/tests/data/homePage.ts
@@ -1,3 +1,5 @@
+import { Colors, ProductCatalog } from './products';
+
 export const ExpectedText = {
   PromoBlocks: [
     'New Luma Yoga Collection Get fit and look fab in new seasonal styles Shop New Yoga',
@@ -10,138 +12,14 @@ export const ExpectedText = {
   ContentHeading: 'Hot Sellers Here is what`s trending on Luma right now',
 };
 
-const Sizes = ['XS', 'S', 'M', 'L', 'XL'];
-
-export const Colors = {
-  Black: 'rgb(0, 0, 0)',
-  Blue: 'rgb(24, 87, 247)',
-  DarkGrey: 'rgb(51, 51, 51)',
-  Green: 'rgb(83, 168, 40)',
-  Grey: 'rgb(143, 143, 143)',
-  LightGrey: 'rgb(240, 240, 240)',
-  Orange: 'rgb(235, 103, 3)',
-  Pink: 'rgb(239, 61, 255)',
-  White: 'rgb(255, 255, 255)',
-  Yellow: 'rgb(255, 213, 0)',
-  Swatch: {
-    Selected: 'rgb(255, 85, 1)',
-    Size: {
-      Hovered: 'rgb(153, 153, 153)',
-      NotSelected: 'rgb(148, 148, 148)',
-    },
-    Color: {
-      Hovered: 'rgb(195, 64, 0)',
-    },
-  },
-};
-
-type Product = {
-  title: string;
-  rating?: string;
-  reviews?: string;
-  price: string;
-  sizes?: string[];
-  colors?: string[];
-  link: string;
-  images: Record<string, string | string[]>;
-};
-
-export const Products: Product[] = [
-  {
-    title: 'Radiant Tee',
-    rating: '60%',
-    reviews: '3 Reviews',
-    price: 'As low as $22.00',
-    sizes: Sizes,
-    colors: [Colors.Blue, Colors.Orange, Colors.Pink],
-    link: '/radiant-tee.html',
-    images: {
-      default: '/w/s/ws12-orange_main_2.jpg',
-      colors: ['/w/s/ws12-blue_main_1.jpg', '/w/s/ws12-orange_main_1.jpg', '/w/s/ws12-purple_main_1.jpg'],
-      // The tee has 2 different images for the size options
-      sizes: [
-        '/w/s/ws12-blue_main_1.jpg',
-        '/w/s/ws12-blue_main_1.jpg',
-        '/w/s/ws12-blue_main_2.jpg',
-        '/w/s/ws12-blue_main_2.jpg',
-        '/w/s/ws12-blue_main_2.jpg',
-      ],
-    },
-  },
-  {
-    title: 'Breathe-Easy Tank',
-    rating: '70%',
-    reviews: '2 Reviews',
-    price: 'As low as $34.00',
-    sizes: Sizes,
-    colors: [Colors.Pink, Colors.White, Colors.Yellow],
-    link: '/breathe-easy-tank.html',
-    images: {
-      default: '/w/t/wt09-white_main_1.jpg',
-      colors: ['/w/t/wt09-purple_main_1.jpg', '/w/t/wt09-white_main_1.jpg', '/w/t/wt09-yellow_main_1.jpg'],
-      sizes: '/w/t/wt09-purple_main_1.jpg',
-    },
-  },
-  {
-    title: 'Argus All-Weather Tank',
-    price: 'As low as $22.00',
-    sizes: Sizes,
-    colors: [Colors.Grey],
-    link: '/argus-all-weather-tank.html',
-    images: {
-      default: '/m/t/mt07-gray_main_1.jpg',
-      colors: ['/m/t/mt07-gray_main_1.jpg'],
-      sizes: '/m/t/mt07-gray_main_1.jpg',
-    },
-  },
-  {
-    title: 'Hero Hoodie',
-    price: 'As low as $54.00',
-    sizes: Sizes,
-    colors: [Colors.Black, Colors.Grey, Colors.Green],
-    link: '/hero-hoodie.html',
-    images: {
-      default: '/m/h/mh07-gray_main_2.jpg',
-      colors: ['/m/h/mh07-black_main_1.jpg', '/m/h/mh07-gray_main_1.jpg', '/m/h/mh07-green_main_1.jpg'],
-      // The hoodie has 2 different images for the size options
-      sizes: [
-        '/m/h/mh07-black_main_1.jpg',
-        '/m/h/mh07-black_main_1.jpg',
-        '/m/h/mh07-black_main_2.jpg',
-        '/m/h/mh07-black_main_2.jpg',
-        '/m/h/mh07-black_main_2.jpg',
-      ],
-    },
-  },
-  {
-    title: 'Fusion Backpack',
-    rating: '67%',
-    reviews: '3 Reviews',
-    price: '$59.00',
-    link: '/fusion-backpack.html',
-    images: { default: '/m/b/mb02-gray-0.jpg' },
-  },
-  {
-    title: 'Push It Messenger Bag',
-    rating: '67%',
-    reviews: '3 Reviews',
-    price: '$45.00',
-    link: '/push-it-messenger-bag.html',
-    images: { default: '/w/b/wb04-blue-0.jpg' },
-  },
+export const Products = [
+  ProductCatalog.RadiantTee,
+  ProductCatalog.BreatheEasyTank,
+  ProductCatalog.ArgusTank,
+  ProductCatalog.HeroHoodie,
+  ProductCatalog.FusionBackpack,
+  ProductCatalog.MessengerBag,
 ];
-
-export const SwatchOutlineStyles = {
-  Sizes: {
-    Selected: `${Colors.Swatch.Selected} solid 2px`,
-    NotSelected: `${Colors.Swatch.Size.NotSelected} none 0px`,
-    Hovered: `${Colors.Swatch.Size.Hovered} solid 1px`,
-  },
-  Colors: {
-    Selected: `${Colors.Swatch.Selected} solid 2px`,
-    Hovered: `${Colors.Swatch.Color.Hovered} solid 2px`,
-  },
-};
 
 export const PromoBlockLinks = [
   '/collections/yoga-new.html',

--- a/tests/data/products.ts
+++ b/tests/data/products.ts
@@ -1,0 +1,132 @@
+const Sizes = ['XS', 'S', 'M', 'L', 'XL'];
+
+export const Colors = {
+  Black: 'rgb(0, 0, 0)',
+  Blue: 'rgb(24, 87, 247)',
+  DarkGrey: 'rgb(51, 51, 51)',
+  Green: 'rgb(83, 168, 40)',
+  Grey: 'rgb(143, 143, 143)',
+  LightGrey: 'rgb(240, 240, 240)',
+  Orange: 'rgb(235, 103, 3)',
+  Pink: 'rgb(239, 61, 255)',
+  White: 'rgb(255, 255, 255)',
+  Yellow: 'rgb(255, 213, 0)',
+  Swatch: {
+    Selected: 'rgb(255, 85, 1)',
+    Size: {
+      Hovered: 'rgb(153, 153, 153)',
+      NotSelected: 'rgb(148, 148, 148)',
+    },
+    Color: {
+      Hovered: 'rgb(195, 64, 0)',
+    },
+  },
+};
+
+export const SwatchOutlineStyles = {
+  Sizes: {
+    Selected: `${Colors.Swatch.Selected} solid 2px`,
+    NotSelected: `${Colors.Swatch.Size.NotSelected} none 0px`,
+    Hovered: `${Colors.Swatch.Size.Hovered} solid 1px`,
+  },
+  Colors: {
+    Selected: `${Colors.Swatch.Selected} solid 2px`,
+    Hovered: `${Colors.Swatch.Color.Hovered} solid 2px`,
+  },
+};
+
+type Product = {
+  title: string;
+  rating?: string;
+  reviews?: string;
+  price: string;
+  sizes?: string[];
+  colors?: string[];
+  link: string;
+  images: Record<string, string | string[]>;
+};
+
+export const ProductCatalog: Record<string, Product> = {
+  RadiantTee: {
+    title: 'Radiant Tee',
+    rating: '60%',
+    reviews: '3 Reviews',
+    price: 'As low as $22.00',
+    sizes: Sizes,
+    colors: [Colors.Blue, Colors.Orange, Colors.Pink],
+    link: '/radiant-tee.html',
+    images: {
+      default: '/w/s/ws12-orange_main_2.jpg',
+      colors: ['/w/s/ws12-blue_main_1.jpg', '/w/s/ws12-orange_main_1.jpg', '/w/s/ws12-purple_main_1.jpg'],
+      // The tee has 2 different images for the size options
+      sizes: [
+        '/w/s/ws12-blue_main_1.jpg',
+        '/w/s/ws12-blue_main_1.jpg',
+        '/w/s/ws12-blue_main_2.jpg',
+        '/w/s/ws12-blue_main_2.jpg',
+        '/w/s/ws12-blue_main_2.jpg',
+      ],
+    },
+  },
+  BreatheEasyTank: {
+    title: 'Breathe-Easy Tank',
+    rating: '70%',
+    reviews: '2 Reviews',
+    price: 'As low as $34.00',
+    sizes: Sizes,
+    colors: [Colors.Pink, Colors.White, Colors.Yellow],
+    link: '/breathe-easy-tank.html',
+    images: {
+      default: '/w/t/wt09-white_main_1.jpg',
+      colors: ['/w/t/wt09-purple_main_1.jpg', '/w/t/wt09-white_main_1.jpg', '/w/t/wt09-yellow_main_1.jpg'],
+      sizes: '/w/t/wt09-purple_main_1.jpg',
+    },
+  },
+  ArgusTank: {
+    title: 'Argus All-Weather Tank',
+    price: 'As low as $22.00',
+    sizes: Sizes,
+    colors: [Colors.Grey],
+    link: '/argus-all-weather-tank.html',
+    images: {
+      default: '/m/t/mt07-gray_main_1.jpg',
+      colors: ['/m/t/mt07-gray_main_1.jpg'],
+      sizes: '/m/t/mt07-gray_main_1.jpg',
+    },
+  },
+  HeroHoodie: {
+    title: 'Hero Hoodie',
+    price: 'As low as $54.00',
+    sizes: Sizes,
+    colors: [Colors.Black, Colors.Grey, Colors.Green],
+    link: '/hero-hoodie.html',
+    images: {
+      default: '/m/h/mh07-gray_main_2.jpg',
+      colors: ['/m/h/mh07-black_main_1.jpg', '/m/h/mh07-gray_main_1.jpg', '/m/h/mh07-green_main_1.jpg'],
+      // The hoodie has 2 different images for the size options
+      sizes: [
+        '/m/h/mh07-black_main_1.jpg',
+        '/m/h/mh07-black_main_1.jpg',
+        '/m/h/mh07-black_main_2.jpg',
+        '/m/h/mh07-black_main_2.jpg',
+        '/m/h/mh07-black_main_2.jpg',
+      ],
+    },
+  },
+  FusionBackpack: {
+    title: 'Fusion Backpack',
+    rating: '67%',
+    reviews: '3 Reviews',
+    price: '$59.00',
+    link: '/fusion-backpack.html',
+    images: { default: '/m/b/mb02-gray-0.jpg' },
+  },
+  MessengerBag: {
+    title: 'Push It Messenger Bag',
+    rating: '67%',
+    reviews: '3 Reviews',
+    price: '$45.00',
+    link: '/push-it-messenger-bag.html',
+    images: { default: '/w/b/wb04-blue-0.jpg' },
+  },
+};

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
 import { HomePage, ProductItemElements } from '../pages/homePage';
-import { ExpectedText, Products, PromoBlockLinks, SwatchOutlineStyles, Colors } from '../data/homePage';
+import { ExpectedText, Products, PromoBlockLinks } from '../data/homePage';
 import { rgbToHex } from '../helpers/colorUtils';
+import { Colors, SwatchOutlineStyles } from '../data/products';
 
 const Timeouts = {
   ImageLink: 10000,


### PR DESCRIPTION
While working on tests for the product category pages it became apparent that the current data model isn't ideal and needed to be updated. The main issue seemed to be the home page data module contained a lot of product data rather than it being centralised in a separate module that can then more easily (and appropriately) be imported into other expected data modules. Because the home page was one of the first pages I tested the expected data was added to the corresponding data module without necessarily thinking about future expansion. This PR resolves that my introducing a common product data module containing things like product sizes, colours etc as well as a full product catalog (or at least as full as is needed at this stage, which is not very).

NB The `ProductCatalog` object in the shared data module is far from the best way of doing things but given this is a 3rd party system and I don't have access to the backend and database that would normally contain such data I don't have too many other choices if I want to write certain types of test. This is a very artificial situation and in reality one shouldn't really test a lot of the scenarios I will write at the UI level - they should be written at a lower level of the test pyramid - but I want to push myself to see how much of the application under test can be tested via Playwright and in doing so build my Playwright skills and experience level