### PR TITLE
Update count assertions

### DIFF
--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -265,7 +265,7 @@ test.describe('Home page tests', () => {
     const tooltipHeight = '90';
     test('Size option tooltips', async () => {
       const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-      expect.soft(await sizes.count()).toEqual(Products[0].sizes!.length);
+      await expect.soft(sizes).toHaveCount(Products[0].sizes!.length);
       for (let i = 0; i < (await sizes.count()); i++) {
         await expect.soft(sizes.nth(i)).toHaveAttribute('option-tooltip-value', Products[0].sizes![i]);
         await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
@@ -275,7 +275,7 @@ test.describe('Home page tests', () => {
 
     test('Color swatch tooltips', async () => {
       const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-      expect.soft(await colors.count()).toEqual(Products[0].colors!.length);
+      await expect.soft(colors).toHaveCount(Products[0].colors!.length);
       for (let i = 0; i < (await colors.count()); i++) {
         await expect.soft(colors.nth(i)).toHaveAttribute('option-tooltip-value', rgbToHex(Products[0].colors![i]));
         await expect.soft(colors.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);

--- a/tests/specs/myAccountPage.spec.ts
+++ b/tests/specs/myAccountPage.spec.ts
@@ -52,13 +52,13 @@ test.describe.skip('My Account page tests', () => {
         .soft(myAccountPage.getBlockElement(myAccountPage.contactInfoBlock, BlockElements.Content))
         .toHaveText(`${dummyCustomer.name}\n${dummyCustomer.email}`);
       let actions = myAccountPage.getBlockElement(myAccountPage.contactInfoBlock, BlockElements.Actions);
-      expect.soft(await actions.count()).toEqual(ExpectedText.AccountInfo.ContactInfo.Actions.length);
+      await expect.soft(actions).toHaveCount(ExpectedText.AccountInfo.ContactInfo.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AccountInfo.ContactInfo.Actions[i]);
       }
       await expect.soft(myAccountPage.addressBookTitle).toHaveText(ExpectedText.AddressBook.Title);
       actions = myAccountPage.addressBookActions;
-      expect.soft(await actions.count()).toEqual(ExpectedText.AddressBook.Actions.length);
+      await expect.soft(actions).toHaveCount(ExpectedText.AddressBook.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.Actions[i]);
       }
@@ -69,7 +69,7 @@ test.describe.skip('My Account page tests', () => {
         .soft(myAccountPage.getBlockElement(myAccountPage.billingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.BillingAddress.Placeholder);
       actions = myAccountPage.getBlockElement(myAccountPage.billingAddressBlock, BlockElements.Actions);
-      expect.soft(await actions.count()).toEqual(ExpectedText.AddressBook.BillingAddress.Actions.length);
+      await expect.soft(actions).toHaveCount(ExpectedText.AddressBook.BillingAddress.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.BillingAddress.Actions[i]);
       }
@@ -80,12 +80,12 @@ test.describe.skip('My Account page tests', () => {
         .soft(myAccountPage.getBlockElement(myAccountPage.shippingAddressBlock, BlockElements.Content))
         .toHaveText(ExpectedText.AddressBook.ShippingAddress.Placeholder);
       actions = myAccountPage.getBlockElement(myAccountPage.shippingAddressBlock, BlockElements.Actions);
-      expect.soft(await actions.count()).toEqual(ExpectedText.AddressBook.ShippingAddress.Actions.length);
+      await expect.soft(actions).toHaveCount(ExpectedText.AddressBook.ShippingAddress.Actions.length);
       for (let i = 0; i < (await actions.count()); i++) {
         await expect.soft(actions.nth(i)).toHaveText(ExpectedText.AddressBook.ShippingAddress.Actions[i]);
       }
       const sidenavOptions = myAccountPage.sidenavOption;
-      expect.soft(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
+      await expect.soft(sidenavOptions).toHaveCount(ExpectedText.PrimarySidenav.length);
       for (let i = 0; i < (await sidenavOptions.count()); i++) {
         await expect.soft(sidenavOptions.nth(i)).toHaveText(ExpectedText.PrimarySidenav[i]);
       }
@@ -104,7 +104,7 @@ test.describe.skip('My Account page tests', () => {
     test('My Account sidenav option selected by default', async () => {
       const selectedClass = /current/;
       const sidenavOptions = myAccountPage.sidenavOption;
-      expect.soft(await sidenavOptions.count()).toEqual(ExpectedText.PrimarySidenav.length);
+      await expect.soft(sidenavOptions).toHaveCount(ExpectedText.PrimarySidenav.length);
       await expect(sidenavOptions.first()).toHaveClass(selectedClass);
       for (let i = 1; i < (await sidenavOptions.count()); i++) {
         await expect.soft(sidenavOptions.nth(i)).not.toHaveClass(selectedClass);
@@ -129,7 +129,7 @@ test.describe.skip('My Account page tests', () => {
   test.describe('Link tests', () => {
     test('Sidenav links', async ({ baseURL }) => {
       const sidenavLinks = myAccountPage.sidenavLink;
-      expect.soft(await sidenavLinks.count()).toEqual(Links.Sidenav.length);
+      await expect.soft(sidenavLinks).toHaveCount(Links.Sidenav.length);
       for (let i = 0; i < (await sidenavLinks.count()); i++) {
         await expect.soft(sidenavLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Sidenav[i]}`);
       }
@@ -137,7 +137,7 @@ test.describe.skip('My Account page tests', () => {
 
     test('Account info links', async ({ baseURL }) => {
       const actionLinks = myAccountPage.getBlockElement(myAccountPage.contactInfoBlock, BlockElements.Actions);
-      expect.soft(await actionLinks.count()).toEqual(Links.ContactInfoActions.length);
+      await expect.soft(actionLinks).toHaveCount(Links.ContactInfoActions.length);
       for (let i = 0; i < (await actionLinks.count()); i++) {
         await expect.soft(actionLinks.nth(i)).toHaveAttribute('href', `${baseURL}${Links.ContactInfoActions[i]}`);
       }

--- a/tests/specs/pageFooter.spec.ts
+++ b/tests/specs/pageFooter.spec.ts
@@ -33,7 +33,7 @@ test.describe('Page footer tests', () => {
 
     test('Text content of page elements', async () => {
       const footerLinks = pageFooter.footerLink;
-      expect.soft(await footerLinks.count()).toEqual(ExpectedText.FooterLinks.length);
+      await expect.soft(footerLinks).toHaveCount(ExpectedText.FooterLinks.length);
       for (let i = 0; i < (await footerLinks.count()); i++) {
         await expect.soft(footerLinks.nth(i)).toHaveText(ExpectedText.FooterLinks[i]);
       }
@@ -55,7 +55,7 @@ test.describe('Page footer tests', () => {
   test.describe('Link tests', () => {
     test('Footer links', async ({ baseURL }) => {
       const footerLinks = pageFooter.footerLink;
-      expect.soft(await footerLinks.count()).toEqual(FooterLinks.length);
+      await expect.soft(footerLinks).toHaveCount(FooterLinks.length);
       for (let i = 0; i < (await footerLinks.count()); i++) {
         const expectedLink = FooterLinks[i].startsWith('https') ? FooterLinks[i] : `${baseURL}${FooterLinks[i]}`;
         await expect.soft(footerLinks.nth(i)).toHaveAttribute('href', expectedLink);

--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -40,7 +40,7 @@ test.describe('Page header tests', () => {
       await expect.soft(pageHeader.searchInput).toBeEmpty();
       await expect.soft(pageHeader.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
       const topnavLinks = pageHeader.topnavLvl0Link;
-      expect.soft(await topnavLinks.count()).toEqual(ExpectedText.Topnav.length);
+      await expect.soft(topnavLinks).toHaveCount(ExpectedText.Topnav.length);
       for (let i = 0; i < (await topnavLinks.count()); i++) {
         await expect.soft(topnavLinks.nth(i)).toHaveText(ExpectedText.Topnav[i]);
       }
@@ -76,7 +76,7 @@ test.describe('Page header tests', () => {
 
     test('Topnav links', async ({ baseURL }) => {
       const lvl0Links = pageHeader.topnavLvl0Link;
-      expect.soft(await lvl0Links.count()).toEqual(Object.keys(TopnavLvl0).length);
+      await expect.soft(lvl0Links).toHaveCount(Object.keys(TopnavLvl0).length);
       for (let i = 0; i < (await lvl0Links.count()); i++) {
         const lvl0Text = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
         await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0Text]}`);
@@ -87,7 +87,7 @@ test.describe('Page header tests', () => {
         // would with a website under my control
         if (lvl0Text !== 'WhatsNew' && lvl0Text !== 'Sale') {
           const subMenuLinks = await pageHeader.getTopnavSubMenuLinks(i);
-          expect.soft(await subMenuLinks.count()).toEqual(Object.keys(Links.Topnav[`${lvl0Text}SubMenu`]).length);
+          await expect.soft(subMenuLinks).toHaveCount(Object.keys(Links.Topnav[`${lvl0Text}SubMenu`]).length);
           for (let j = 0; j < (await subMenuLinks.count()); j++) {
             const subMenuText = (await subMenuLinks.nth(j).innerText()).replace(/\W+/g, '');
             await expect


### PR DESCRIPTION
I must have been having something of a brain fart when I wrote some of the assertions in these tests as I completely forgot about `toHaveCount()` which is exactly what I am verifying before looping through various elements. By using this assertion this should make the tests a little more robust and reliable, as well as being a better pattern for verifying element counts