### PR TITLE
Product item tests

### DIFF
--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { HomePage } from '../pages/homePage';
 import { ExpectedText, Products, PromoBlockLinks } from '../data/homePage';
-import { rgbToHex } from '../helpers/colorUtils';
-import { Colors, SwatchOutlineStyles } from '../data/products';
+import { Colors } from '../data/products';
 import { ProductItemElements } from '../pages/components/productItem';
 
 const Timeouts = {
@@ -20,8 +19,6 @@ test.describe('Home page tests', () => {
   test.describe('Appearance tests', () => {
     // This is an example of performing visual-style testing by asserting against various element properties rather than actually using image comparison
     // The tests could be combined but I have split them here to make them easier to read and maintain
-
-    const swatchSelectedClass = /selected/;
 
     test('Main page elements displayed', async () => {
       await expect.soft(homePage.globalMessage).toBeVisible();
@@ -80,83 +77,6 @@ test.describe('Home page tests', () => {
             await expect.soft(colors.nth(j)).toHaveCSS('background-color', Products[i].colors![j]);
           }
         }
-        await productItems.nth(i).hover();
-        await expect.soft(homePage.getProductItemElement(i, ProductItemElements.AddToCartButton)).toBeVisible();
-        await expect.soft(homePage.getProductItemElement(i, ProductItemElements.AddToWishListButton)).toBeVisible();
-        await expect.soft(homePage.getProductItemElement(i, ProductItemElements.AddToCompareButton)).toBeVisible();
-      }
-    });
-
-    test('Product swatch styling', async ({ browserName }) => {
-      // There is no need to test the swatches on all product items since they all use the same element
-      // Similarly there is no need to test every size/colour swatch for a given product
-      const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-
-      // Select
-      await sizes.first().click();
-      await expect.soft(sizes.first()).toHaveClass(swatchSelectedClass);
-      await expect.soft(sizes.first()).toHaveCSS('outline', SwatchOutlineStyles.Sizes.Hovered);
-      await expect.soft(sizes.first()).toHaveCSS('background-color', Colors.White);
-      // For some reason a simple blur() isn't enough so hover over another element
-      await homePage.getProductItemElement(0, ProductItemElements.Name).hover();
-      await expect.soft(sizes.first()).toHaveCSS('outline', SwatchOutlineStyles.Sizes.Selected);
-
-      //Deselect
-      await sizes.first().click();
-      await expect.soft(sizes.first()).not.toHaveClass(swatchSelectedClass);
-      await expect.soft(sizes.first()).toHaveCSS('outline', SwatchOutlineStyles.Sizes.Hovered);
-      await expect.soft(sizes.first()).toHaveCSS('background-color', Colors.LightGrey);
-      await homePage.getProductItemElement(0, ProductItemElements.Name).hover();
-      const outlineStyle =
-        browserName === 'firefox'
-          ? // Firefox doesn't include "none" in the outline style but other browsers do
-            SwatchOutlineStyles.Sizes.NotSelected.replace('none ', '')
-          : SwatchOutlineStyles.Sizes.NotSelected;
-      await expect.soft(sizes.first()).toHaveCSS('outline', outlineStyle);
-
-      const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-
-      // Select
-      await colors.first().click();
-      await expect.soft(colors.first()).toHaveClass(swatchSelectedClass);
-      await expect.soft(colors.first()).toHaveCSS('outline', SwatchOutlineStyles.Colors.Hovered);
-      // For some reason a simple blur() isn't enough so hover over another element
-      await homePage.getProductItemElement(0, ProductItemElements.Name).hover();
-      await expect.soft(colors.first()).toHaveCSS('outline', SwatchOutlineStyles.Colors.Selected);
-
-      //Deselect
-      await colors.first().click();
-      await expect.soft(colors.first()).not.toHaveClass(swatchSelectedClass);
-      await expect.soft(colors.first()).toHaveCSS('outline', SwatchOutlineStyles.Colors.Hovered);
-    });
-
-    test('Can only select single size option at a time', async () => {
-      // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
-      const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-      await expect.soft(sizes).toHaveCount(Products[0].sizes!.length);
-      for (let i = 0; i < (await sizes.count()); i++) {
-        await sizes.nth(i).click();
-        await expect.soft(sizes.nth(i)).toHaveClass(swatchSelectedClass);
-        for (let j = 0; j < (await sizes.count()); j++) {
-          if (j !== i) {
-            await expect.soft(sizes.nth(j)).not.toHaveClass(swatchSelectedClass);
-          }
-        }
-      }
-    });
-
-    test('Can only select single color option at a time', async () => {
-      // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
-      const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-      await expect.soft(colors).toHaveCount(Products[0].colors!.length);
-      for (let i = 0; i < (await colors.count()); i++) {
-        await colors.nth(i).click();
-        await expect.soft(colors.nth(i)).toHaveClass(swatchSelectedClass);
-        for (let j = 0; j < (await colors.count()); j++) {
-          if (j !== i) {
-            await expect.soft(colors.nth(j)).not.toHaveClass(swatchSelectedClass);
-          }
-        }
       }
     });
   });
@@ -167,11 +87,6 @@ test.describe('Home page tests', () => {
         mask: [homePage.adsWidget],
         timeout: Timeouts.Visual,
       });
-    });
-
-    test('Product hover', async () => {
-      await homePage.productItem.nth(0).hover();
-      await expect(homePage.productsGrid).toHaveScreenshot('productHover.png', { timeout: Timeouts.Visual });
     });
 
     // There is no need for visual testing of the product images for the various colour options as we can verify
@@ -256,30 +171,6 @@ test.describe('Home page tests', () => {
               .toHaveAttribute('src', imageLink, { timeout: Timeouts.ImageLink });
           }
         }
-      }
-    });
-  });
-
-  test.describe('Tooltip tests', () => {
-    const tooltipWidth = '110';
-    const tooltipHeight = '90';
-    test('Size option tooltips', async () => {
-      const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
-      await expect.soft(sizes).toHaveCount(Products[0].sizes!.length);
-      for (let i = 0; i < (await sizes.count()); i++) {
-        await expect.soft(sizes.nth(i)).toHaveAttribute('option-tooltip-value', Products[0].sizes![i]);
-        await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
-        await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-height', tooltipHeight);
-      }
-    });
-
-    test('Color swatch tooltips', async () => {
-      const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
-      await expect.soft(colors).toHaveCount(Products[0].colors!.length);
-      for (let i = 0; i < (await colors.count()); i++) {
-        await expect.soft(colors.nth(i)).toHaveAttribute('option-tooltip-value', rgbToHex(Products[0].colors![i]));
-        await expect.soft(colors.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
-        await expect.soft(colors.nth(i)).toHaveAttribute('thumb-height', tooltipHeight);
       }
     });
   });

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -163,7 +163,7 @@ test.describe('Home page tests', () => {
 
     test('Product image links for different color options', async ({ baseURL }) => {
       const products = homePage.productItem;
-      await expect.soft(await products).toHaveCount(Products.length);
+      await expect.soft(products).toHaveCount(Products.length);
       for (let i = 0; i < (await products.count()); i++) {
         if (Products[i].colors) {
           const colors = homePage.getProductItemElement(i, ProductItemElements.Colors);

--- a/tests/specs/homePage.spec.ts
+++ b/tests/specs/homePage.spec.ts
@@ -89,6 +89,11 @@ test.describe('Home page tests', () => {
       });
     });
 
+    test('Product hover', async () => {
+      await homePage.productItem.first().hover();
+      await expect(homePage.productsGrid).toHaveScreenshot('productHover.png', { timeout: Timeouts.Visual });
+    });
+
     // There is no need for visual testing of the product images for the various colour options as we can verify
     // the image src links for each option instead(below).This is a more efficient testing method as we don't have
     // to maintain the baseline images for all products in all colours across all supported browsers and platforms

--- a/tests/specs/productCategoryPage.spec.ts
+++ b/tests/specs/productCategoryPage.spec.ts
@@ -86,16 +86,6 @@ test.describe('Product category page tests', () => {
             await expect.soft(colors.nth(j)).toHaveCSS('background-color', productDetails[i].colors![j]);
           }
         }
-        await productItems.nth(i).hover();
-        await expect
-          .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.AddToCartButton))
-          .toBeVisible();
-        await expect
-          .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.AddToWishListButton))
-          .toBeVisible();
-        await expect
-          .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.AddToCompareButton))
-          .toBeVisible();
       }
     });
   });

--- a/tests/specs/productItem.spec.ts
+++ b/tests/specs/productItem.spec.ts
@@ -5,10 +5,6 @@ import { Colors, SwatchOutlineStyles } from '../data/products';
 import { Products } from '../data/homePage';
 import { rgbToHex } from '../helpers/colorUtils';
 
-const Timeouts = {
-  Visual: 20000,
-};
-
 test.describe('Product item tests', () => {
   // These tests could use any page that has product items on it. It just so happens that I have chosen the home page for simplicity
   let homePage: HomePage;
@@ -98,13 +94,6 @@ test.describe('Product item tests', () => {
           }
         }
       }
-    });
-  });
-
-  test.describe('Visual tests', () => {
-    test('Product hover', async () => {
-      await homePage.productItem.first().hover();
-      await expect(homePage.productsGrid).toHaveScreenshot('productHover.png', { timeout: Timeouts.Visual });
     });
   });
 

--- a/tests/specs/productItem.spec.ts
+++ b/tests/specs/productItem.spec.ts
@@ -7,6 +7,7 @@ import { rgbToHex } from '../helpers/colorUtils';
 
 test.describe('Product item tests', () => {
   // These tests could use any page that has product items on it. It just so happens that I have chosen the home page for simplicity
+  // In the future this could be extended to use a random page with products on
   let homePage: HomePage;
   test.beforeEach(async ({ page }) => {
     homePage = new HomePage(page);

--- a/tests/specs/productItem.spec.ts
+++ b/tests/specs/productItem.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+import { HomePage } from '../pages/homePage';
+import { ProductItemElements } from '../pages/components/productItem';
+import { Colors, SwatchOutlineStyles } from '../data/products';
+import { Products } from '../data/homePage';
+import { rgbToHex } from '../helpers/colorUtils';
+
+const Timeouts = {
+  Visual: 20000,
+};
+
+test.describe('Product item tests', () => {
+  // These tests could use any page that has product items on it. It just so happens that I have chosen the home page for simplicity
+  let homePage: HomePage;
+  test.beforeEach(async ({ page }) => {
+    homePage = new HomePage(page);
+    await homePage.open();
+  });
+
+  test.describe('Appearance tests', () => {
+    const swatchSelectedClass = /selected/;
+
+    test('Additional controls displayed on hover', async () => {
+      await homePage.productItem.first().hover();
+      await expect.soft(homePage.getProductItemElement(0, ProductItemElements.AddToCartButton)).toBeVisible();
+      await expect.soft(homePage.getProductItemElement(0, ProductItemElements.AddToWishListButton)).toBeVisible();
+      await expect.soft(homePage.getProductItemElement(0, ProductItemElements.AddToCompareButton)).toBeVisible();
+    });
+
+    test('Product swatch styling', async ({ browserName }) => {
+      // There is no need to test the swatches on all product items since they all use the same element
+      // Similarly there is no need to test every size/colour swatch for a given product
+      const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
+
+      // Select
+      await sizes.first().click();
+      await expect.soft(sizes.first()).toHaveClass(swatchSelectedClass);
+      await expect.soft(sizes.first()).toHaveCSS('outline', SwatchOutlineStyles.Sizes.Hovered);
+      await expect.soft(sizes.first()).toHaveCSS('background-color', Colors.White);
+      // For some reason a simple blur() isn't enough so hover over another element
+      await homePage.getProductItemElement(0, ProductItemElements.Name).hover();
+      await expect.soft(sizes.first()).toHaveCSS('outline', SwatchOutlineStyles.Sizes.Selected);
+
+      //Deselect
+      await sizes.first().click();
+      await expect.soft(sizes.first()).not.toHaveClass(swatchSelectedClass);
+      await expect.soft(sizes.first()).toHaveCSS('outline', SwatchOutlineStyles.Sizes.Hovered);
+      await expect.soft(sizes.first()).toHaveCSS('background-color', Colors.LightGrey);
+      await homePage.getProductItemElement(0, ProductItemElements.Name).hover();
+      const outlineStyle =
+        browserName === 'firefox'
+          ? // Firefox doesn't include "none" in the outline style but other browsers do
+            SwatchOutlineStyles.Sizes.NotSelected.replace('none ', '')
+          : SwatchOutlineStyles.Sizes.NotSelected;
+      await expect.soft(sizes.first()).toHaveCSS('outline', outlineStyle);
+
+      const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
+
+      // Select
+      await colors.first().click();
+      await expect.soft(colors.first()).toHaveClass(swatchSelectedClass);
+      await expect.soft(colors.first()).toHaveCSS('outline', SwatchOutlineStyles.Colors.Hovered);
+      // For some reason a simple blur() isn't enough so hover over another element
+      await homePage.getProductItemElement(0, ProductItemElements.Name).hover();
+      await expect.soft(colors.first()).toHaveCSS('outline', SwatchOutlineStyles.Colors.Selected);
+
+      //Deselect
+      await colors.first().click();
+      await expect.soft(colors.first()).not.toHaveClass(swatchSelectedClass);
+      await expect.soft(colors.first()).toHaveCSS('outline', SwatchOutlineStyles.Colors.Hovered);
+    });
+
+    test('Can only select single size option at a time', async () => {
+      // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
+      const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
+      await expect.soft(sizes).toHaveCount(Products[0].sizes!.length);
+      for (let i = 0; i < (await sizes.count()); i++) {
+        await sizes.nth(i).click();
+        await expect.soft(sizes.nth(i)).toHaveClass(swatchSelectedClass);
+        for (let j = 0; j < (await sizes.count()); j++) {
+          if (j !== i) {
+            await expect.soft(sizes.nth(j)).not.toHaveClass(swatchSelectedClass);
+          }
+        }
+      }
+    });
+
+    test('Can only select single color option at a time', async () => {
+      // The styling of the 'selected' class is tested above so just checking whether an element has the class is sufficient here
+      const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
+      await expect.soft(colors).toHaveCount(Products[0].colors!.length);
+      for (let i = 0; i < (await colors.count()); i++) {
+        await colors.nth(i).click();
+        await expect.soft(colors.nth(i)).toHaveClass(swatchSelectedClass);
+        for (let j = 0; j < (await colors.count()); j++) {
+          if (j !== i) {
+            await expect.soft(colors.nth(j)).not.toHaveClass(swatchSelectedClass);
+          }
+        }
+      }
+    });
+  });
+
+  test.describe('Visual tests', () => {
+    test('Product hover', async () => {
+      await homePage.productItem.first().hover();
+      await expect(homePage.productsGrid).toHaveScreenshot('productHover.png', { timeout: Timeouts.Visual });
+    });
+  });
+
+  test.describe('Tooltip tests', () => {
+    const tooltipWidth = '110';
+    const tooltipHeight = '90';
+    test('Size option tooltips', async () => {
+      const sizes = homePage.getProductItemElement(0, ProductItemElements.Sizes);
+      await expect.soft(sizes).toHaveCount(Products[0].sizes!.length);
+      for (let i = 0; i < (await sizes.count()); i++) {
+        await expect.soft(sizes.nth(i)).toHaveAttribute('option-tooltip-value', Products[0].sizes![i]);
+        await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
+        await expect.soft(sizes.nth(i)).toHaveAttribute('thumb-height', tooltipHeight);
+      }
+    });
+
+    test('Color swatch tooltips', async () => {
+      const colors = homePage.getProductItemElement(0, ProductItemElements.Colors);
+      await expect.soft(colors).toHaveCount(Products[0].colors!.length);
+      for (let i = 0; i < (await colors.count()); i++) {
+        await expect.soft(colors.nth(i)).toHaveAttribute('option-tooltip-value', rgbToHex(Products[0].colors![i]));
+        await expect.soft(colors.nth(i)).toHaveAttribute('thumb-width', tooltipWidth);
+        await expect.soft(colors.nth(i)).toHaveAttribute('thumb-height', tooltipHeight);
+      }
+    });
+  });
+});


### PR DESCRIPTION
When I wrote the home page spec I added tests for various aspects of the product item cards displayed on that page. Having now added tests for the product category pages it has become apparent that these tests belong to a new spec for the product item component to avoid overlap and duplication between specs. The product items tests are currently based on the home page products but in the future the tests could run against any page with products