### PR TITLE
Initial collection page tests

### DIFF
--- a/tests/data/collectionPage.ts
+++ b/tests/data/collectionPage.ts
@@ -8,3 +8,7 @@ export const Collections = {
 export const ExpectedText = {
   Women: { ...Women.ExpectedText },
 };
+
+export const Products = {
+  Women: [...Women.Products],
+};

--- a/tests/data/collectionPage.ts
+++ b/tests/data/collectionPage.ts
@@ -1,4 +1,5 @@
 import { TopnavLvl0 } from './pageHeader';
+import * as WhatsNew from './collections/whatsNew';
 import * as Women from './collections/women';
 
 export const Collections = {
@@ -6,13 +7,16 @@ export const Collections = {
 };
 
 export const ExpectedText = {
+  WhatsNew: { ...WhatsNew.ExpectedText },
   Women: { ...Women.ExpectedText },
 };
 
 export const Links = {
+  WhatsNew: { ...WhatsNew.Links },
   Women: { ...Women.Links },
 };
 
 export const Products = {
+  WhatsNew: [...WhatsNew.Products],
   Women: [...Women.Products],
 };

--- a/tests/data/collectionPage.ts
+++ b/tests/data/collectionPage.ts
@@ -1,22 +1,26 @@
 import { TopnavLvl0 } from './pageHeader';
 import * as WhatsNew from './collections/whatsNew';
 import * as Women from './collections/women';
+import * as Men from './collections/men';
 
 export const Collections = {
   ...TopnavLvl0,
 };
 
 export const ExpectedText = {
+  Men: { ...Men.ExpectedText },
   WhatsNew: { ...WhatsNew.ExpectedText },
   Women: { ...Women.ExpectedText },
 };
 
 export const Links = {
+  Men: { ...Men.Links },
   WhatsNew: { ...WhatsNew.Links },
   Women: { ...Women.Links },
 };
 
 export const Products = {
+  Men: [...Men.Products],
   WhatsNew: [...WhatsNew.Products],
   Women: [...Women.Products],
 };

--- a/tests/data/collectionPage.ts
+++ b/tests/data/collectionPage.ts
@@ -2,24 +2,28 @@ import { TopnavLvl0 } from './pageHeader';
 import * as WhatsNew from './collections/whatsNew';
 import * as Women from './collections/women';
 import * as Men from './collections/men';
+import * as Gear from './collections/gear';
 
 export const Collections = {
   ...TopnavLvl0,
 };
 
 export const ExpectedText = {
+  Gear: { ...Gear.ExpectedText },
   Men: { ...Men.ExpectedText },
   WhatsNew: { ...WhatsNew.ExpectedText },
   Women: { ...Women.ExpectedText },
 };
 
 export const Links = {
+  Gear: { ...Gear.Links },
   Men: { ...Men.Links },
   WhatsNew: { ...WhatsNew.Links },
   Women: { ...Women.Links },
 };
 
 export const Products = {
+  Gear: [...Gear.Products],
   Men: [...Men.Products],
   WhatsNew: [...WhatsNew.Products],
   Women: [...Women.Products],

--- a/tests/data/collectionPage.ts
+++ b/tests/data/collectionPage.ts
@@ -4,6 +4,7 @@ import * as Women from './collections/women';
 import * as Men from './collections/men';
 import * as Gear from './collections/gear';
 import * as Training from './collections/training';
+import * as Sale from './collections/sale';
 
 export const Collections = {
   ...TopnavLvl0,
@@ -12,6 +13,7 @@ export const Collections = {
 export const ExpectedText = {
   Gear: { ...Gear.ExpectedText },
   Men: { ...Men.ExpectedText },
+  Sale: { ...Sale.ExpectedText },
   Training: { ...Training.ExpectedText },
   WhatsNew: { ...WhatsNew.ExpectedText },
   Women: { ...Women.ExpectedText },
@@ -20,6 +22,7 @@ export const ExpectedText = {
 export const Links = {
   Gear: { ...Gear.Links },
   Men: { ...Men.Links },
+  Sale: { ...Sale.Links },
   Training: { ...Training.Links },
   WhatsNew: { ...WhatsNew.Links },
   Women: { ...Women.Links },
@@ -28,6 +31,7 @@ export const Links = {
 export const Products = {
   Gear: [...Gear.Products],
   Men: [...Men.Products],
+  Sale: [...Sale.Products],
   Training: [...Training.Products],
   WhatsNew: [...WhatsNew.Products],
   Women: [...Women.Products],

--- a/tests/data/collectionPage.ts
+++ b/tests/data/collectionPage.ts
@@ -1,5 +1,10 @@
 import { TopnavLvl0 } from './pageHeader';
+import * as Women from './collections/women';
 
 export const Collections = {
   ...TopnavLvl0,
+};
+
+export const ExpectedText = {
+  Women: { ...Women.ExpectedText },
 };

--- a/tests/data/collectionPage.ts
+++ b/tests/data/collectionPage.ts
@@ -1,0 +1,5 @@
+import { TopnavLvl0 } from './pageHeader';
+
+export const Collections = {
+  ...TopnavLvl0,
+};

--- a/tests/data/collectionPage.ts
+++ b/tests/data/collectionPage.ts
@@ -9,6 +9,10 @@ export const ExpectedText = {
   Women: { ...Women.ExpectedText },
 };
 
+export const Links = {
+  Women: { ...Women.Links },
+};
+
 export const Products = {
   Women: [...Women.Products],
 };

--- a/tests/data/collectionPage.ts
+++ b/tests/data/collectionPage.ts
@@ -3,6 +3,7 @@ import * as WhatsNew from './collections/whatsNew';
 import * as Women from './collections/women';
 import * as Men from './collections/men';
 import * as Gear from './collections/gear';
+import * as Training from './collections/training';
 
 export const Collections = {
   ...TopnavLvl0,
@@ -11,6 +12,7 @@ export const Collections = {
 export const ExpectedText = {
   Gear: { ...Gear.ExpectedText },
   Men: { ...Men.ExpectedText },
+  Training: { ...Training.ExpectedText },
   WhatsNew: { ...WhatsNew.ExpectedText },
   Women: { ...Women.ExpectedText },
 };
@@ -18,6 +20,7 @@ export const ExpectedText = {
 export const Links = {
   Gear: { ...Gear.Links },
   Men: { ...Men.Links },
+  Training: { ...Training.Links },
   WhatsNew: { ...WhatsNew.Links },
   Women: { ...Women.Links },
 };
@@ -25,6 +28,7 @@ export const Links = {
 export const Products = {
   Gear: [...Gear.Products],
   Men: [...Men.Products],
+  Training: [...Training.Products],
   WhatsNew: [...WhatsNew.Products],
   Women: [...Women.Products],
 };

--- a/tests/data/collections/gear.ts
+++ b/tests/data/collections/gear.ts
@@ -1,0 +1,38 @@
+import { Product } from '../products';
+import { CollectionExpectedText } from './shared';
+import * as Bags from '../productCategories/gearBags';
+import * as Equipment from '../productCategories/gearFitnessEquipment';
+import { Links as HeaderLinks } from '../pageHeader';
+
+export const ExpectedText: CollectionExpectedText = {
+  Breadcrumbs: 'Home  Gear',
+  Title: 'Gear',
+  PromoBlocks: [
+    'Sprite Yoga Companion Kit\nSave up to 20% on a bundle!\nShop Yoga Kit',
+    'Loosen Up\nExtend your training with yoga straps, tone bands,\nand jump ropes\nShop Fitness',
+    'Here’s to you!\n$4 Luma water bottle\n(save 70%)\nEnter promo code H2O\nat check out',
+    'Tote, cart or carry\nLuma bags go the distance\nShop Bags',
+    'Let’s get after it!\nLuma gym equipment fits your goals and style\nShop Equipment',
+    'Luma watches\nKeeping pace has never been more stylish\nShop Watches',
+  ],
+  ProductsGrid: {
+    Title: 'Hot Sellers',
+    Subtitle: 'Favorites from Luma shoppers',
+  },
+};
+
+export const Links = {
+  Breadcrumbs: {
+    Home: '/',
+  },
+  PromoBlocks: [
+    HeaderLinks.Topnav.Gear,
+    HeaderLinks.Topnav.GearSubMenu.FitnessEquipment,
+    HeaderLinks.Topnav.GearSubMenu.FitnessEquipment,
+    HeaderLinks.Topnav.GearSubMenu.Bags,
+    HeaderLinks.Topnav.GearSubMenu.FitnessEquipment,
+    HeaderLinks.Topnav.GearSubMenu.Watches,
+  ],
+};
+
+export const Products: Product[] = [Bags.Products[8], Bags.Products[0], Equipment.Products[10], Equipment.Products[0]];

--- a/tests/data/collections/men.ts
+++ b/tests/data/collections/men.ts
@@ -1,0 +1,40 @@
+import { Product } from '../products';
+import { CollectionExpectedText } from './shared';
+import * as Hoodies from '../productCategories/menHoodies';
+import * as Pants from '../productCategories/menPants';
+import * as Shorts from '../productCategories/menShorts';
+import * as Tanks from '../productCategories/menTanks';
+import { Links as HeaderLinks } from '../pageHeader';
+
+export const ExpectedText: CollectionExpectedText = {
+  Breadcrumbs: 'Home  Men',
+  Title: 'Men',
+  PromoBlocks: [
+    'Luma’s Performance Fabric collection\nGoing the extra mile just got extra comfortable\nShop Performance',
+    'Save up to $24!\nBuy 3 Luma tees, get 4 instead\nShop Tees',
+    'Last chance\nfor pants\nTake\n20% OFF\nand save bigtime*\nShop Pants',
+    'Luma shorts\nCool it now\nShop Shorts',
+    'Luma tees\nGrab a tee or two!\nShop Tees',
+    'Luma hoodies\nDress for fitness\nShop Hoodies',
+  ],
+  ProductsGrid: {
+    Title: 'Hot Sellers',
+    Subtitle: 'Favorites from Luma shoppers',
+  },
+};
+
+export const Links = {
+  Breadcrumbs: {
+    Home: '/',
+  },
+  PromoBlocks: [
+    HeaderLinks.Topnav.Men,
+    HeaderLinks.Topnav.MenSubMenu.Tees,
+    HeaderLinks.Topnav.MenSubMenu.Pants,
+    HeaderLinks.Topnav.MenSubMenu.Shorts,
+    HeaderLinks.Topnav.MenSubMenu.Tees,
+    HeaderLinks.Topnav.MenSubMenu.HoodiesSweatshirts,
+  ],
+};
+
+export const Products: Product[] = [Tanks.Products[5], Hoodies.Products[6], Shorts.Products[9], Pants.Products[9]];

--- a/tests/data/collections/sale.ts
+++ b/tests/data/collections/sale.ts
@@ -1,0 +1,35 @@
+import { Product } from '../products';
+import { CollectionExpectedText } from './shared';
+import * as Bags from '../productCategories/gearBags';
+import * as Equipment from '../productCategories/gearFitnessEquipment';
+import { Links as HeaderLinks } from '../pageHeader';
+
+export const ExpectedText: CollectionExpectedText = {
+  Breadcrumbs: 'Home  Sale',
+  Title: 'Sale',
+  PromoBlocks: [
+    'Women’s Deals\nPristine prices on pants, tanks and bras.\nShop Women’s Deals',
+    'Men’s Bargains\nStretch your budget with active attire\nShop Men’s Deals',
+    'Luma Gear Steals\nYour best efforts deserve a deal\nShop Luma Gear',
+    '20% OFF\nEvery $200-plus purchase!',
+    'Spend $50 or more — shipping is free!\nBuy more, save more',
+    "You can't have too many tees\n4 tees for the price of 3. Right now\nTees on sale",
+  ],
+  ProductsGrid: {},
+};
+
+export const Links = {
+  Breadcrumbs: {
+    Home: '/',
+  },
+  PromoBlocks: [
+    '/promotions/women-sale.html',
+    '/promotions/men-sale.html',
+    HeaderLinks.Topnav.Gear,
+    '',
+    '',
+    HeaderLinks.Topnav.WomenSubMenu.Tees,
+  ],
+};
+
+export const Products: Product[] = [];

--- a/tests/data/collections/shared.ts
+++ b/tests/data/collections/shared.ts
@@ -1,0 +1,6 @@
+export type CollectionExpectedText = {
+  Breadcrumbs: string;
+  Title: string;
+  PromoBlocks: string[];
+  ProductsGrid: Record<string, string>;
+};

--- a/tests/data/collections/training.ts
+++ b/tests/data/collections/training.ts
@@ -1,0 +1,32 @@
+import { Product } from '../products';
+import { CollectionExpectedText } from './shared';
+import * as Bags from '../productCategories/gearBags';
+import * as Equipment from '../productCategories/gearFitnessEquipment';
+import { Links as HeaderLinks } from '../pageHeader';
+
+export const ExpectedText: CollectionExpectedText = {
+  Breadcrumbs: 'Home  Training',
+  Title: 'Training',
+  PromoBlocks: [
+    'Motivate yourself.\nReach goals.\nBoost ambition.\nMax fitness.\nUpgrade lifestyle.',
+    'Before creating Luma, pro trainer Erin Renny helped world-class athletes reach peak fitness\nHand-selected by Erin, our training downloads reflect a commitment to yoga, health and wellness.',
+    'Download\nTraining on demand\nLuma downloads to inspire and challenge.\nYour space, your pace\nVideos',
+  ],
+  ProductsGrid: {
+    Title: 'Top Videos',
+    Subtitle: 'Stream free with subscription',
+  },
+};
+
+export const Links = {
+  Breadcrumbs: {
+    Home: '/',
+  },
+  PromoBlocks: [
+    HeaderLinks.Topnav.Training,
+    '/collections/erin-recommends.html',
+    HeaderLinks.Topnav.TrainingSubMenu.VideoDownload,
+  ],
+};
+
+export const Products: Product[] = [];

--- a/tests/data/collections/whatsNew.ts
+++ b/tests/data/collections/whatsNew.ts
@@ -1,0 +1,34 @@
+import { Product } from '../products';
+import { CollectionExpectedText } from './shared';
+import * as WomenHoodies from '../productCategories/womenHoodies';
+import * as WomenJackets from '../productCategories/womenJackets';
+import * as MenTees from '../productCategories/menTees';
+import { Links as HeaderLinks } from '../pageHeader';
+
+export const ExpectedText: CollectionExpectedText = {
+  Breadcrumbs: "Home  What's New",
+  Title: "What's New",
+  PromoBlocks: [
+    'New Luma Yoga Collection\nThe very latest yoga styles plus twists on timeless classics\nShop New Yoga',
+    'Whatever day brings\nLuma Cocona™ for breathability, CoolTech™ for wicking, or a blend of both.\nPerformance Fabrics',
+    'A sense of renewal\nEnjoy comfort of body and mind with Luma eco-friendly choices\nShop Eco Friendly ',
+  ],
+  ProductsGrid: {
+    Title: "Luma's Latest",
+    Subtitle: 'Just in time for the new season!',
+  },
+};
+
+export const Links = {
+  Breadcrumbs: {
+    Home: '/',
+  },
+  PromoBlocks: ['/collections/yoga-new.html', '/collections/performance-new.html', '/collections/eco-new.html'],
+};
+
+export const Products: Product[] = [
+  WomenHoodies.Products[5],
+  MenTees.Products[11],
+  WomenJackets.Products[11],
+  MenTees.Products[5],
+];

--- a/tests/data/collections/women.ts
+++ b/tests/data/collections/women.ts
@@ -1,0 +1,19 @@
+import { CollectionExpectedText } from './shared';
+
+export const ExpectedText: CollectionExpectedText = {
+  Breadcrumbs: 'Home  Women',
+  Title: 'Women',
+  PromoBlocks: [
+    'New Luma Yoga Collection\nYoga is ancient\nClothing shouldn’t be\nShop New Yoga',
+    'You can’t have too many tees\n4 tees for the price of 3. Right now\nWomen’s Tees',
+    'Hot pants\nHot deals\n20% OFF\nLuma pants when you shop today*\nShop Pants',
+    'What would Erin wear?\nIt’s no secret: see Luma founder Erin Renny’s wardrobe go-to’s\nShop Erin Recommends\t',
+    'Luma pants\nPants for yoga, gym and outdoors\nShop Pants',
+    'Luma shorts\nExercise comfort\nShop Shorts',
+    'Luma Bras\nTanks\nStock up for summer!\nShop Now',
+  ],
+  ProductsGrid: {
+    Title: 'Hot Sellers',
+    Subtitle: 'Favorites from Luma shoppers',
+  },
+};

--- a/tests/data/collections/women.ts
+++ b/tests/data/collections/women.ts
@@ -1,4 +1,9 @@
+import { Product } from '../products';
 import { CollectionExpectedText } from './shared';
+import * as Hoodies from '../productCategories/womenHoodies';
+import * as Pants from '../productCategories/womenPants';
+import * as Tanks from '../productCategories/womenTanks';
+import * as Tees from '../productCategories/womenTees';
 
 export const ExpectedText: CollectionExpectedText = {
   Breadcrumbs: 'Home  Women',
@@ -17,3 +22,5 @@ export const ExpectedText: CollectionExpectedText = {
     Subtitle: 'Favorites from Luma shoppers',
   },
 };
+
+export const Products: Product[] = [Tees.Products[2], Tanks.Products[0], Hoodies.Products[7], Pants.Products[1]];

--- a/tests/data/collections/women.ts
+++ b/tests/data/collections/women.ts
@@ -4,6 +4,7 @@ import * as Hoodies from '../productCategories/womenHoodies';
 import * as Pants from '../productCategories/womenPants';
 import * as Tanks from '../productCategories/womenTanks';
 import * as Tees from '../productCategories/womenTees';
+import { Links as HeaderLinks } from '../pageHeader';
 
 export const ExpectedText: CollectionExpectedText = {
   Breadcrumbs: 'Home  Women',
@@ -27,6 +28,15 @@ export const Links = {
   Breadcrumbs: {
     Home: '/',
   },
+  PromoBlocks: [
+    HeaderLinks.Topnav.Women,
+    HeaderLinks.Topnav.WomenSubMenu.Tees,
+    HeaderLinks.Topnav.WomenSubMenu.Pants,
+    '/collections/erin-recommends.html',
+    HeaderLinks.Topnav.WomenSubMenu.Pants,
+    HeaderLinks.Topnav.WomenSubMenu.Shorts,
+    HeaderLinks.Topnav.WomenSubMenu.BrasTanks,
+  ],
 };
 
 export const Products: Product[] = [Tees.Products[2], Tanks.Products[0], Hoodies.Products[7], Pants.Products[1]];

--- a/tests/data/collections/women.ts
+++ b/tests/data/collections/women.ts
@@ -23,4 +23,10 @@ export const ExpectedText: CollectionExpectedText = {
   },
 };
 
+export const Links = {
+  Breadcrumbs: {
+    Home: '/',
+  },
+};
+
 export const Products: Product[] = [Tees.Products[2], Tanks.Products[0], Hoodies.Products[7], Pants.Products[1]];

--- a/tests/data/productCategories/womenTees.ts
+++ b/tests/data/productCategories/womenTees.ts
@@ -1,5 +1,5 @@
 import { Links as HeaderLinks } from '../pageHeader';
-import { Colors, Sizes } from '../products';
+import { Colors, Product, Sizes } from '../products';
 import { FilterOptions, ProductCategoryExpectedText } from './shared';
 
 export const ExpectedText: ProductCategoryExpectedText = {

--- a/tests/pages/collectionPage.ts
+++ b/tests/pages/collectionPage.ts
@@ -11,6 +11,8 @@ export default class CollectionPage extends BasePage {
   readonly primarySidebar: Locator;
   readonly secondarySidebar: Locator;
   readonly promoBlock: Locator;
+  readonly productsGridTitle: Locator;
+  readonly productsGridSubtitle: Locator;
   readonly productsGrid: Locator;
   readonly productItem: Locator;
 
@@ -24,6 +26,8 @@ export default class CollectionPage extends BasePage {
     this.secondarySidebar = this.mainContent.locator('.sidebar-additional');
     this.promoBlock = this.mainContent.locator('.block-promo');
     this.productsGrid = this.mainContent.locator('.products-grid');
+    this.productsGridTitle = this.mainContent.locator('.content-heading').getByRole('heading', { level: 2 });
+    this.productsGridSubtitle = this.mainContent.locator('.content-heading').locator('.info');
     this.productItem = new ProductItem(this.productsGrid).product;
   }
 

--- a/tests/pages/collectionPage.ts
+++ b/tests/pages/collectionPage.ts
@@ -1,0 +1,44 @@
+import { Locator, Page } from '@playwright/test';
+import BasePage from './basePage';
+import ProductItem, { ProductItemElements } from './components/productItem';
+import { Collections } from '../data/collectionPage';
+
+export default class CollectionPage extends BasePage {
+  readonly breadcrumbsContainer: Locator;
+  readonly breadcrumb: Locator;
+  readonly mainContent: Locator;
+  readonly pageTitle: Locator;
+  readonly primarySidebar: Locator;
+  readonly secondarySidebar: Locator;
+  readonly promoBlock: Locator;
+  readonly productsGrid: Locator;
+  readonly productItem: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.breadcrumbsContainer = page.locator('.breadcrumbs');
+    this.breadcrumb = this.breadcrumbsContainer.locator('a');
+    this.mainContent = page.locator('#maincontent');
+    this.pageTitle = this.mainContent.getByRole('heading', { level: 1 });
+    this.primarySidebar = this.mainContent.locator('.sidebar-main');
+    this.secondarySidebar = this.mainContent.locator('.sidebar-additional');
+    this.promoBlock = this.mainContent.locator('.block-promo');
+    this.productsGrid = this.mainContent.locator('.products-grid');
+    this.productItem = new ProductItem(this.productsGrid).product;
+  }
+
+  async open(url?: string): Promise<void> {
+    // Open random product category page or specific page if url passed in
+    if (typeof url === 'undefined') {
+      const topLvlCategory = Object.keys(Collections)[Math.floor(Math.random() * Object.keys(Collections).length)];
+      url = Object.values(Collections[topLvlCategory])[
+        Math.floor(Math.random() * Object.keys(Collections[topLvlCategory]).length)
+      ] as string;
+    }
+    await super.open(url);
+  }
+
+  getProductItemElement(productIndex: number, element: ProductItemElements): Locator {
+    return this.productItem.nth(productIndex).locator(element);
+  }
+}

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import CollectionPage from '../pages/collectionPage';
+import { Collections } from '../data/collectionPage';
+
+test.describe('Collection page tests', () => {
+  let collectionPage: CollectionPage;
+  let collection: string;
+  test.beforeEach(async ({ page }) => {
+    collectionPage = new CollectionPage(page);
+    // const topLvlCategory = Object.keys(Collections)[Math.floor(Math.random() * Object.keys(Collections).length)];
+    // const subCategory = Object.keys(Collections[topLvlCategory])[
+    //   Math.floor(Math.random() * Object.keys(Collections[topLvlCategory]).length)
+    // ];
+    // category = `${topLvlCategory}${subCategory}`;
+    // await collectionPage.open(Collections[topLvlCategory][subCategory]);
+
+    // Hardcode page for now
+    collection = 'Women';
+    await collectionPage.open(Collections.Women);
+  });
+
+  test.describe('Appearance tests', () => {
+    // This is an example of performing visual-style testing by asserting against various element properties rather than actually using image comparison
+    // The tests could be combined but I have split them here to make them easier to read and maintain
+
+    test('Main page elements displayed', async () => {
+      await expect.soft(collectionPage.globalMessage).toBeVisible();
+      await expect.soft(collectionPage.pageHeader.header).toBeVisible();
+      await expect.soft(collectionPage.pageHeader.topnav).toBeVisible();
+      await expect.soft(collectionPage.breadcrumbsContainer).toBeVisible();
+      await expect.soft(collectionPage.primarySidebar).toBeVisible();
+      await expect.soft(collectionPage.secondarySidebar).toBeVisible();
+      await expect.soft(collectionPage.productsGrid).toBeVisible();
+      await expect.soft(collectionPage.pageFooter.footer).toBeVisible();
+      await expect.soft(collectionPage.pageFooter.copyrightFooter).toBeVisible();
+
+      // To be replaced by dynamic values depending on collection
+      await expect.soft(collectionPage.promoBlock).toHaveCount(7);
+      await expect.soft(collectionPage.productItem).toHaveCount(4);
+    });
+  });
+});

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -103,5 +103,26 @@ test.describe('Collection page tests', () => {
           .toHaveAttribute('href', `${baseURL}${Links[collection].Breadcrumbs[breadcrumbs[i]]}`);
       }
     });
+
+    test('Product links', async ({ baseURL }) => {
+      const productDetails = Products[collection].slice(0, 12);
+      const products = collectionPage.productItem;
+      await expect.soft(products).toHaveCount(productDetails.length);
+      for (let i = 0; i < (await products.count()); i++) {
+        await expect
+          .soft(collectionPage.getProductItemElement(i, ProductItemElements.PhotoLink))
+          .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
+        await expect
+          .soft(collectionPage.getProductItemElement(i, ProductItemElements.NameLink))
+          .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
+        if (productDetails[i].reviews) {
+          await expect
+            .soft(collectionPage.getProductItemElement(i, ProductItemElements.ReviewsLink))
+            .toHaveAttribute('href', `${baseURL}${productDetails[i].link}#reviews`);
+        } else {
+          await expect.soft(collectionPage.getProductItemElement(i, ProductItemElements.ReviewsLink)).not.toBeVisible();
+        }
+      }
+    });
   });
 });

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -31,7 +31,7 @@ test.describe('Collection page tests', () => {
       await expect.soft(collectionPage.breadcrumbsContainer).toBeVisible();
       await expect.soft(collectionPage.primarySidebar).toBeVisible();
       await expect.soft(collectionPage.secondarySidebar).toBeVisible();
-      await expect.soft(collectionPage.productsGrid).toBeVisible();
+      if (Products[collection].length) await expect.soft(collectionPage.productsGrid).toBeVisible();
       await expect.soft(collectionPage.pageFooter.footer).toBeVisible();
       await expect.soft(collectionPage.pageFooter.copyrightFooter).toBeVisible();
 
@@ -112,7 +112,7 @@ test.describe('Collection page tests', () => {
     });
 
     test('Product links', async ({ baseURL }) => {
-      const productDetails = Products[collection].slice(0, 12);
+      const productDetails = Products[collection];
       const products = collectionPage.productItem;
       await expect.soft(products).toHaveCount(productDetails.length);
       for (let i = 0; i < (await products.count()); i++) {

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -104,6 +104,14 @@ test.describe('Collection page tests', () => {
       }
     });
 
+    test('Promo block links', async ({ baseURL }) => {
+      const promoBlocks = collectionPage.promoBlock;
+      await expect.soft(promoBlocks).toHaveCount(Links[collection].PromoBlocks.length);
+      for (let i = 0; i < (await promoBlocks.count()); i++) {
+        await expect.soft(promoBlocks.nth(i)).toHaveAttribute('href', `${baseURL}${Links[collection].PromoBlocks[i]}`);
+      }
+    });
+
     test('Product links', async ({ baseURL }) => {
       const productDetails = Products[collection].slice(0, 12);
       const products = collectionPage.productItem;

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -35,9 +35,8 @@ test.describe('Collection page tests', () => {
       await expect.soft(collectionPage.pageFooter.footer).toBeVisible();
       await expect.soft(collectionPage.pageFooter.copyrightFooter).toBeVisible();
 
-      // To be replaced by dynamic values depending on collection
-      await expect.soft(collectionPage.promoBlock).toHaveCount(7);
-      await expect.soft(collectionPage.productItem).toHaveCount(4);
+      await expect.soft(collectionPage.promoBlock).toHaveCount(ExpectedText[collection].PromoBlocks.length);
+      await expect.soft(collectionPage.productItem).toHaveCount(Products[collection].length);
     });
 
     test('Text content of page elements', async () => {

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -107,7 +107,11 @@ test.describe('Collection page tests', () => {
       const promoBlocks = collectionPage.promoBlock;
       await expect.soft(promoBlocks).toHaveCount(Links[collection].PromoBlocks.length);
       for (let i = 0; i < (await promoBlocks.count()); i++) {
-        await expect.soft(promoBlocks.nth(i)).toHaveAttribute('href', `${baseURL}${Links[collection].PromoBlocks[i]}`);
+        if (Links[collection].PromoBlocks[i]) {
+          await expect
+            .soft(promoBlocks.nth(i))
+            .toHaveAttribute('href', `${baseURL}${Links[collection].PromoBlocks[i]}`);
+        }
       }
     });
 

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import CollectionPage from '../pages/collectionPage';
-import { Collections, ExpectedText } from '../data/collectionPage';
+import { Collections, ExpectedText, Products } from '../data/collectionPage';
+import { ProductItemElements } from '../pages/components/productItem';
 
 test.describe('Collection page tests', () => {
   let collectionPage: CollectionPage;
@@ -51,6 +52,44 @@ test.describe('Collection page tests', () => {
       }
       await expect.soft(collectionPage.productsGridTitle).toHaveText(collectionExpectedText.ProductsGrid.Title);
       await expect.soft(collectionPage.productsGridSubtitle).toHaveText(collectionExpectedText.ProductsGrid.Subtitle);
+    });
+
+    test('Product item details', async () => {
+      const productDetails = Products[collection];
+      const productItems = collectionPage.productItem;
+      await expect.soft(productItems).toHaveCount(productDetails.length);
+      for (let i = 0; i < (await productItems.count()); i++) {
+        await expect
+          .soft(collectionPage.getProductItemElement(i, ProductItemElements.Name))
+          .toHaveText(productDetails[i].title);
+        if (productDetails[i].rating) {
+          await expect
+            .soft(collectionPage.getProductItemElement(i, ProductItemElements.Rating))
+            .toHaveText(productDetails[i].rating!);
+        }
+        if (productDetails[i].reviews) {
+          await expect
+            .soft(collectionPage.getProductItemElement(i, ProductItemElements.Reviews))
+            .toHaveText(productDetails[i].reviews!);
+        }
+        await expect
+          .soft(collectionPage.getProductItemElement(i, ProductItemElements.Price).first())
+          .toHaveText(productDetails[i].price);
+        if (productDetails[i].sizes) {
+          const sizes = collectionPage.getProductItemElement(i, ProductItemElements.Sizes);
+          await expect.soft(sizes).toHaveCount(productDetails[i].sizes!.length);
+          for (let j = 0; j < (await sizes.count()); j++) {
+            await expect.soft(sizes.nth(j)).toHaveText(productDetails[i].sizes![j]);
+          }
+        }
+        if (productDetails[i].colors) {
+          const colors = collectionPage.getProductItemElement(i, ProductItemElements.Colors);
+          await expect.soft(colors).toHaveCount(productDetails[i].colors!.length);
+          for (let j = 0; j < (await colors.count()); j++) {
+            await expect.soft(colors.nth(j)).toHaveCSS('background-color', productDetails[i].colors![j]);
+          }
+        }
+      }
     });
   });
 });

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -8,16 +8,9 @@ test.describe('Collection page tests', () => {
   let collection: string;
   test.beforeEach(async ({ page }) => {
     collectionPage = new CollectionPage(page);
-    // const topLvlCategory = Object.keys(Collections)[Math.floor(Math.random() * Object.keys(Collections).length)];
-    // const subCategory = Object.keys(Collections[topLvlCategory])[
-    //   Math.floor(Math.random() * Object.keys(Collections[topLvlCategory]).length)
-    // ];
-    // category = `${topLvlCategory}${subCategory}`;
-    // await collectionPage.open(Collections[topLvlCategory][subCategory]);
-
-    // Hardcode page for now
-    collection = 'Women';
-    await collectionPage.open(Collections.Women);
+    collection = Object.keys(Collections)[Math.floor(Math.random() * Object.keys(Collections).length)];
+    await collectionPage.open(Collections[collection]);
+    console.log(collection);
   });
 
   test.describe('Appearance tests', () => {

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import CollectionPage from '../pages/collectionPage';
-import { Collections, ExpectedText, Products } from '../data/collectionPage';
+import { Collections, ExpectedText, Links, Products } from '../data/collectionPage';
 import { ProductItemElements } from '../pages/components/productItem';
 
 test.describe('Collection page tests', () => {
@@ -89,6 +89,18 @@ test.describe('Collection page tests', () => {
             await expect.soft(colors.nth(j)).toHaveCSS('background-color', productDetails[i].colors![j]);
           }
         }
+      }
+    });
+  });
+
+  test.describe('Link tests', () => {
+    test('Breadcrumb links', async ({ baseURL }) => {
+      const breadcrumbs = (await collectionPage.breadcrumbsContainer.innerText()).split('  ');
+      // The last breadcrumb doesn't have a link as it is the current page
+      for (let i = 0; i < breadcrumbs.length - 1; i++) {
+        await expect
+          .soft(collectionPage.breadcrumb.nth(i))
+          .toHaveAttribute('href', `${baseURL}${Links[collection].Breadcrumbs[breadcrumbs[i]]}`);
       }
     });
   });

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import CollectionPage from '../pages/collectionPage';
-import { Collections } from '../data/collectionPage';
+import { Collections, ExpectedText } from '../data/collectionPage';
 
 test.describe('Collection page tests', () => {
   let collectionPage: CollectionPage;
@@ -37,6 +37,20 @@ test.describe('Collection page tests', () => {
       // To be replaced by dynamic values depending on collection
       await expect.soft(collectionPage.promoBlock).toHaveCount(7);
       await expect.soft(collectionPage.productItem).toHaveCount(4);
+    });
+
+    test('Text content of page elements', async () => {
+      const collectionExpectedText = ExpectedText[collection];
+      await expect.soft(collectionPage.breadcrumbsContainer).toHaveText(collectionExpectedText.Breadcrumbs);
+      await expect.soft(collectionPage.pageTitle).toHaveText(collectionExpectedText.Title);
+      // Add sidebar expected text verification
+      const promoBlocks = collectionPage.promoBlock;
+      await expect.soft(promoBlocks).toHaveCount(collectionExpectedText.PromoBlocks.length);
+      for (let i = 0; i < (await promoBlocks.count()); i++) {
+        await expect.soft(promoBlocks.nth(i)).toHaveText(collectionExpectedText.PromoBlocks[i], { useInnerText: true });
+      }
+      await expect.soft(collectionPage.productsGridTitle).toHaveText(collectionExpectedText.ProductsGrid.Title);
+      await expect.soft(collectionPage.productsGridSubtitle).toHaveText(collectionExpectedText.ProductsGrid.Subtitle);
     });
   });
 });


### PR DESCRIPTION
These tests are similar to those previously added for product category pages and again use a random collection page to reduce duplication while still maintaining coverage