### PR TITLE
Rework topnav tests

### DIFF
--- a/tests/data/pageHeader.ts
+++ b/tests/data/pageHeader.ts
@@ -22,24 +22,32 @@ export const TopnavLvl0 = {
 
 const WomenSubMenu = {
   Tops: '/women/tops-women.html',
-  Jackets: '/women/tops-women/jackets-women.html',
-  HoodiesSweatshirts: '/women/tops-women/hoodies-and-sweatshirts-women.html',
-  Tees: '/women/tops-women/tees-women.html',
-  BrasTanks: '/women/tops-women/tanks-women.html',
+  TopsSubMenu: {
+    Jackets: '/women/tops-women/jackets-women.html',
+    HoodiesSweatshirts: '/women/tops-women/hoodies-and-sweatshirts-women.html',
+    Tees: '/women/tops-women/tees-women.html',
+    BrasTanks: '/women/tops-women/tanks-women.html',
+  },
   Bottoms: '/women/bottoms-women.html',
-  Pants: '/women/bottoms-women/pants-women.html',
-  Shorts: '/women/bottoms-women/shorts-women.html',
+  BottomsSubMenu: {
+    Pants: '/women/bottoms-women/pants-women.html',
+    Shorts: '/women/bottoms-women/shorts-women.html',
+  },
 };
 
 const MenSubMenu = {
   Tops: '/men/tops-men.html',
-  Jackets: '/men/tops-men/jackets-men.html',
-  HoodiesSweatshirts: '/men/tops-men/hoodies-and-sweatshirts-men.html',
-  Tees: '/men/tops-men/tees-men.html',
-  Tanks: '/men/tops-men/tanks-men.html',
+  TopsSubMenu: {
+    Jackets: '/men/tops-men/jackets-men.html',
+    HoodiesSweatshirts: '/men/tops-men/hoodies-and-sweatshirts-men.html',
+    Tees: '/men/tops-men/tees-men.html',
+    Tanks: '/men/tops-men/tanks-men.html',
+  },
   Bottoms: '/men/bottoms-men.html',
-  Pants: '/men/bottoms-men/pants-men.html',
-  Shorts: '/men/bottoms-men/shorts-men.html',
+  BottomsSubMenu: {
+    Pants: '/men/bottoms-men/pants-men.html',
+    Shorts: '/men/bottoms-men/shorts-men.html',
+  },
 };
 
 const GearSubMenu = {

--- a/tests/data/productCategoryPage.ts
+++ b/tests/data/productCategoryPage.ts
@@ -20,8 +20,18 @@ import * as GearFitnessEquipment from './productCategories/gearFitnessEquipment'
 import * as GearWatches from './productCategories/gearWatches';
 
 export const ProductCategories = {
-  Women: { ...HeaderLinks.Topnav.WomenSubMenu },
-  Men: { ...HeaderLinks.Topnav.MenSubMenu },
+  Women: {
+    Tops: HeaderLinks.Topnav.WomenSubMenu.Tops,
+    ...HeaderLinks.Topnav.WomenSubMenu.TopsSubMenu,
+    Bottoms: HeaderLinks.Topnav.WomenSubMenu.Bottoms,
+    ...HeaderLinks.Topnav.WomenSubMenu.BottomsSubMenu,
+  },
+  Men: {
+    Tops: HeaderLinks.Topnav.MenSubMenu.Tops,
+    ...HeaderLinks.Topnav.MenSubMenu.TopsSubMenu,
+    Bottoms: HeaderLinks.Topnav.MenSubMenu.Bottoms,
+    ...HeaderLinks.Topnav.MenSubMenu.BottomsSubMenu,
+  },
   Gear: { ...HeaderLinks.Topnav.GearSubMenu },
   // There are no products under Training > Video Downloads so the whole Training category is omitted
 };

--- a/tests/pages/components/pageHeader.ts
+++ b/tests/pages/components/pageHeader.ts
@@ -10,8 +10,6 @@ export default class PageHeader {
   readonly searchInput: Locator;
   readonly cartLink: Locator;
   readonly topnav: Locator;
-  readonly topnavLink: Locator;
-  readonly topnavLvl0Link: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -22,17 +20,9 @@ export default class PageHeader {
     this.logo = this.header.locator('a.logo');
     this.searchInput = this.header.locator('input#search');
     this.cartLink = this.header.locator('a.showcart');
-    this.topnav = page.locator('.nav-sections');
     this.topnav = page.locator('nav');
-    this.topnavLink = this.topnav.getByRole('menuitem');
-    this.topnavLvl0Link = this.topnav.locator('li.level0').getByRole('menuitem');
   }
 
-  async getTopnavSubMenuItems(lvl0Index: number, lvl: 1 | 2): Promise<Locator> {
-    return this.topnavLvl0Link.nth(lvl0Index).locator('..').locator(`li.level${lvl}`);
-  }
-
-  async getTopnavLink(menuItem: Locator): Promise<Locator> {
   async getTopnavMenuItem(menu: Locator, lvl: number): Promise<Locator> {
     return menu.locator(`li.level${lvl}`);
   }

--- a/tests/pages/components/pageHeader.ts
+++ b/tests/pages/components/pageHeader.ts
@@ -27,7 +27,11 @@ export default class PageHeader {
     this.topnavLvl0Link = this.topnav.locator('li.level0').getByRole('menuitem');
   }
 
-  async getTopnavSubMenuLinks(lvl0Index: number): Promise<Locator> {
-    return this.topnavLvl0Link.nth(lvl0Index).locator('..').locator('li.level1 a');
+  async getTopnavSubMenuItems(lvl0Index: number, lvl: 1 | 2): Promise<Locator> {
+    return this.topnavLvl0Link.nth(lvl0Index).locator('..').locator(`li.level${lvl}`);
+  }
+
+  async getTopnavLink(menuItem: Locator): Promise<Locator> {
+    return menuItem.locator('a');
   }
 }

--- a/tests/pages/components/pageHeader.ts
+++ b/tests/pages/components/pageHeader.ts
@@ -23,6 +23,7 @@ export default class PageHeader {
     this.searchInput = this.header.locator('input#search');
     this.cartLink = this.header.locator('a.showcart');
     this.topnav = page.locator('.nav-sections');
+    this.topnav = page.locator('nav');
     this.topnavLink = this.topnav.getByRole('menuitem');
     this.topnavLvl0Link = this.topnav.locator('li.level0').getByRole('menuitem');
   }
@@ -32,6 +33,11 @@ export default class PageHeader {
   }
 
   async getTopnavLink(menuItem: Locator): Promise<Locator> {
-    return menuItem.locator('a');
+  async getTopnavMenuItem(menu: Locator, lvl: number): Promise<Locator> {
+    return menu.locator(`li.level${lvl}`);
+  }
+
+  async getTopnavMenuLink(menuItem: Locator): Promise<Locator> {
+    return menuItem.locator('a').first();
   }
 }

--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -78,21 +78,46 @@ test.describe('Page header tests', () => {
       const lvl0Links = pageHeader.topnavLvl0Link;
       await expect.soft(lvl0Links).toHaveCount(Object.keys(TopnavLvl0).length);
       for (let i = 0; i < (await lvl0Links.count()); i++) {
-        const lvl0Text = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
-        await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0Text]}`);
+        const lvl0MenuText = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
+        await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0MenuText]}`);
 
         // This section of the test isn't as neat as I would have liked. I wanted to verify the submenu levels individually
         // e.g Women has Tops and Bottoms as level 1 menu items each with individual submenus. However, the DOM makes that
-        // awkward and as I am using a 3rd - party website I can't edit the DOM to add suitable locators/attributes as I
+        // awkward and as I am using a 3rd-party website I can't edit the DOM to add suitable locators/attributes as I
         // would with a website under my control
-        if (lvl0Text !== 'WhatsNew' && lvl0Text !== 'Sale') {
-          const subMenuLinks = await pageHeader.getTopnavSubMenuLinks(i);
-          await expect.soft(subMenuLinks).toHaveCount(Object.keys(Links.Topnav[`${lvl0Text}SubMenu`]).length);
-          for (let j = 0; j < (await subMenuLinks.count()); j++) {
-            const subMenuText = (await subMenuLinks.nth(j).innerText()).replace(/\W+/g, '');
+        if (lvl0MenuText !== 'WhatsNew' && lvl0MenuText !== 'Sale') {
+          // Lvl 1 menu items e.g. Women > Tops
+          const lvl1MenuItems = await pageHeader.getTopnavSubMenuItems(i, 1);
+          // const lvl1MenuItems = await pageHeader.getTopnavLink(lvl0Links.nth(i));
+          const lvl1Keys = Object.keys(Links.Topnav[`${lvl0MenuText}SubMenu`]).filter(
+            (key) => !key.endsWith('SubMenu'),
+          );
+          await expect.soft(lvl1MenuItems).toHaveCount(lvl1Keys.length);
+          for (let j = 0; j < (await lvl1MenuItems.count()); j++) {
+            const link = lvl1MenuItems.nth(j).locator('a').first();
+            const lvl1MenuText = (await link.innerText()).replace(/\W+/g, '');
             await expect
-              .soft(subMenuLinks.nth(j))
-              .toHaveAttribute('href', `${baseURL}${Links.Topnav[`${lvl0Text}SubMenu`][subMenuText]}`);
+              .soft(link)
+              .toHaveAttribute('href', `${baseURL}${Links.Topnav[`${lvl0MenuText}SubMenu`][lvl1MenuText]}`);
+            if (lvl0MenuText === 'Women' || lvl0MenuText === 'Men') {
+              // Lvl 2 menu items e.g. Women > Tops > Jackets
+              const lvl2MenuItems = await pageHeader.getTopnavLink(lvl1MenuItems.nth(j));
+              const lvl2Submenu = Object.keys(Links.Topnav[`${lvl0MenuText}SubMenu`]).filter((key) =>
+                key.endsWith('SubMenu'),
+              )[j];
+              const lvl2Keys = Object.keys(Links.Topnav[`${lvl0MenuText}SubMenu`][lvl2Submenu]);
+              await expect.soft(lvl2MenuItems).toHaveCount(lvl2Keys.length + 1);
+              for (let k = 1; k < (await lvl2MenuItems.count()); k++) {
+                const link = lvl2MenuItems.nth(k);
+                const lvl2MenuText = (await link.innerText()).replace(/\W+/g, '');
+                await expect
+                  .soft(link)
+                  .toHaveAttribute(
+                    'href',
+                    `${baseURL}${Links.Topnav[`${lvl0MenuText}SubMenu`][`${lvl1MenuText}SubMenu`][lvl2MenuText]}`,
+                  );
+              }
+            }
           }
         }
       }

--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -39,10 +39,13 @@ test.describe('Page header tests', () => {
       await expect.soft(pageHeader.banner).toHaveText(ExpectedText.Banner);
       await expect.soft(pageHeader.searchInput).toBeEmpty();
       await expect.soft(pageHeader.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
-      const topnavLinks = pageHeader.topnavLvl0Link;
-      await expect.soft(topnavLinks).toHaveCount(ExpectedText.Topnav.length);
-      for (let i = 0; i < (await topnavLinks.count()); i++) {
-        await expect.soft(topnavLinks.nth(i)).toHaveText(ExpectedText.Topnav[i]);
+      const topnavMenuItems = await pageHeader.getTopnavMenuItem(pageHeader.topnav, 0);
+      await expect.soft(topnavMenuItems).toHaveCount(ExpectedText.Topnav.length);
+      for (let i = 0; i < (await topnavMenuItems.count()); i++) {
+        // It's the links that have the expected text; the menu items themselves include all submenu item text contents
+        await expect
+          .soft(await pageHeader.getTopnavMenuLink(topnavMenuItems.nth(i)))
+          .toHaveText(ExpectedText.Topnav[i]);
       }
     });
   });

--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -75,40 +75,39 @@ test.describe('Page header tests', () => {
     });
 
     test('Topnav links', async ({ baseURL }) => {
-      const lvl0Links = pageHeader.topnavLvl0Link;
+      // This test isn't as neat as I would have liked as I am using a 3rd-party website so I can't
+      // edit the DOM to add suitable locators/attributes as I would with a website under my control
+      const lvl0Links = await pageHeader.getTopnavMenuItem(pageHeader.topnav, 0);
       await expect.soft(lvl0Links).toHaveCount(Object.keys(TopnavLvl0).length);
       for (let i = 0; i < (await lvl0Links.count()); i++) {
         const lvl0MenuText = (await lvl0Links.nth(i).innerText()).replace(/\W+/g, '');
-        await expect.soft(lvl0Links.nth(i)).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0MenuText]}`);
+        const link = await pageHeader.getTopnavMenuLink(lvl0Links.nth(i));
+        await expect.soft(link).toHaveAttribute('href', `${baseURL}${Links.Topnav[lvl0MenuText]}`);
 
-        // This section of the test isn't as neat as I would have liked. I wanted to verify the submenu levels individually
-        // e.g Women has Tops and Bottoms as level 1 menu items each with individual submenus. However, the DOM makes that
-        // awkward and as I am using a 3rd-party website I can't edit the DOM to add suitable locators/attributes as I
-        // would with a website under my control
-        if (lvl0MenuText !== 'WhatsNew' && lvl0MenuText !== 'Sale') {
-          // Lvl 1 menu items e.g. Women > Tops
-          const lvl1MenuItems = await pageHeader.getTopnavSubMenuItems(i, 1);
-          // const lvl1MenuItems = await pageHeader.getTopnavLink(lvl0Links.nth(i));
+        // Lvl 1 menu items e.g. Women > Tops
+        const lvl1MenuItems = await pageHeader.getTopnavMenuItem(lvl0Links.nth(i), 1);
+        if ((await lvl1MenuItems.count()) > 0) {
           const lvl1Keys = Object.keys(Links.Topnav[`${lvl0MenuText}SubMenu`]).filter(
             (key) => !key.endsWith('SubMenu'),
           );
           await expect.soft(lvl1MenuItems).toHaveCount(lvl1Keys.length);
           for (let j = 0; j < (await lvl1MenuItems.count()); j++) {
-            const link = lvl1MenuItems.nth(j).locator('a').first();
+            const link = await pageHeader.getTopnavMenuLink(lvl1MenuItems.nth(j));
             const lvl1MenuText = (await link.innerText()).replace(/\W+/g, '');
             await expect
               .soft(link)
               .toHaveAttribute('href', `${baseURL}${Links.Topnav[`${lvl0MenuText}SubMenu`][lvl1MenuText]}`);
-            if (lvl0MenuText === 'Women' || lvl0MenuText === 'Men') {
-              // Lvl 2 menu items e.g. Women > Tops > Jackets
-              const lvl2MenuItems = await pageHeader.getTopnavLink(lvl1MenuItems.nth(j));
+
+            // Lvl 2 menu items e.g. Women > Tops > Jackets
+            const lvl2MenuItems = await pageHeader.getTopnavMenuItem(lvl1MenuItems.nth(j), 2);
+            if ((await lvl2MenuItems.count()) > 0) {
               const lvl2Submenu = Object.keys(Links.Topnav[`${lvl0MenuText}SubMenu`]).filter((key) =>
                 key.endsWith('SubMenu'),
               )[j];
               const lvl2Keys = Object.keys(Links.Topnav[`${lvl0MenuText}SubMenu`][lvl2Submenu]);
-              await expect.soft(lvl2MenuItems).toHaveCount(lvl2Keys.length + 1);
+              await expect.soft(lvl2MenuItems).toHaveCount(lvl2Keys.length);
               for (let k = 1; k < (await lvl2MenuItems.count()); k++) {
-                const link = lvl2MenuItems.nth(k);
+                const link = await pageHeader.getTopnavMenuLink(lvl2MenuItems.nth(k));
                 const lvl2MenuText = (await link.innerText()).replace(/\W+/g, '');
                 await expect
                   .soft(link)


### PR DESCRIPTION
As seems to the case all too often at the minute I have done some refactoring driven by something that came up for other tests I am currently developing. This time I have restructured the topnav test data to better reflect the actual menu structure and updated the tests accordingly. Hopefully this will help when it comes to verifying the correct topnav items are highlighted when product category/collection pages are selected