### PR TITLE
Skip failing page header tests

### DIFF
--- a/tests/specs/pageHeader.spec.ts
+++ b/tests/specs/pageHeader.spec.ts
@@ -35,7 +35,7 @@ test.describe('Page header tests', () => {
       await expect.soft(pageHeader.topnav).toHaveCSS('color', Colors.DarkGrey);
     });
 
-    test('Text content of page elements', async () => {
+    test.skip('Text content of page elements', async () => {
       await expect.soft(pageHeader.banner).toHaveText(ExpectedText.Banner);
       await expect.soft(pageHeader.searchInput).toBeEmpty();
       await expect.soft(pageHeader.searchInput).toHaveAttribute('placeholder', ExpectedText.Search);
@@ -50,7 +50,7 @@ test.describe('Page header tests', () => {
     });
   });
 
-  test.describe('Visual tests', () => {
+  test.describe.skip('Visual tests', () => {
     test('Default page header appearance', async () => {
       await expect(pageHeader.header).toHaveScreenshot('header.png', {
         timeout: Timeouts.Visual,


### PR DESCRIPTION
The 3rd-party website under test has recently undergone a host migration and as a result they have changed the text displayed in the banner in the page header which causes a few of my tests of that functionality, including the visual tests, to fail. I hope these changes are only temporary but I will keep a watching brief. In the meantime, in order to maintain a green test pipeline I am skipping the failing tests with a view to reinstating them as soon as it becomes clear whether the banner text changes are permanent or not. 

NB I have skipped the whole "text content" check even though it contains several assertions that would still pass. This means a slight dip in test coverage but the skipped test will show up in the run logs whereas just commenting out the failed assertion would pass the test but there is then no obvious way of seeing from the logs that an assertion has been omitted.