### PR TITLE
Fix collection page tests

### DIFF
--- a/tests/data/collections/men.ts
+++ b/tests/data/collections/men.ts
@@ -29,11 +29,11 @@ export const Links = {
   },
   PromoBlocks: [
     HeaderLinks.Topnav.Men,
-    HeaderLinks.Topnav.MenSubMenu.Tees,
-    HeaderLinks.Topnav.MenSubMenu.Pants,
-    HeaderLinks.Topnav.MenSubMenu.Shorts,
-    HeaderLinks.Topnav.MenSubMenu.Tees,
-    HeaderLinks.Topnav.MenSubMenu.HoodiesSweatshirts,
+    HeaderLinks.Topnav.MenSubMenu.TopsSubMenu.Tees,
+    HeaderLinks.Topnav.MenSubMenu.BottomsSubMenu.Pants,
+    HeaderLinks.Topnav.MenSubMenu.BottomsSubMenu.Shorts,
+    HeaderLinks.Topnav.MenSubMenu.TopsSubMenu.Tees,
+    HeaderLinks.Topnav.MenSubMenu.TopsSubMenu.HoodiesSweatshirts,
   ],
 };
 

--- a/tests/data/collections/sale.ts
+++ b/tests/data/collections/sale.ts
@@ -28,7 +28,7 @@ export const Links = {
     HeaderLinks.Topnav.Gear,
     '',
     '',
-    HeaderLinks.Topnav.WomenSubMenu.Tees,
+    HeaderLinks.Topnav.WomenSubMenu.TopsSubMenu.Tees,
   ],
 };
 

--- a/tests/data/collections/sale.ts
+++ b/tests/data/collections/sale.ts
@@ -1,7 +1,5 @@
 import { Product } from '../products';
 import { CollectionExpectedText } from './shared';
-import * as Bags from '../productCategories/gearBags';
-import * as Equipment from '../productCategories/gearFitnessEquipment';
 import { Links as HeaderLinks } from '../pageHeader';
 
 export const ExpectedText: CollectionExpectedText = {

--- a/tests/data/collections/women.ts
+++ b/tests/data/collections/women.ts
@@ -30,12 +30,12 @@ export const Links = {
   },
   PromoBlocks: [
     HeaderLinks.Topnav.Women,
-    HeaderLinks.Topnav.WomenSubMenu.Tees,
-    HeaderLinks.Topnav.WomenSubMenu.Pants,
+    HeaderLinks.Topnav.WomenSubMenu.TopsSubMenu.Tees,
+    HeaderLinks.Topnav.WomenSubMenu.BottomsSubMenu.Pants,
     '/collections/erin-recommends.html',
-    HeaderLinks.Topnav.WomenSubMenu.Pants,
-    HeaderLinks.Topnav.WomenSubMenu.Shorts,
-    HeaderLinks.Topnav.WomenSubMenu.BrasTanks,
+    HeaderLinks.Topnav.WomenSubMenu.BottomsSubMenu.Pants,
+    HeaderLinks.Topnav.WomenSubMenu.BottomsSubMenu.Shorts,
+    HeaderLinks.Topnav.WomenSubMenu.TopsSubMenu.BrasTanks,
   ],
 };
 

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -124,7 +124,7 @@ test.describe('Collection page tests', () => {
       const promoBlocks = collectionPage.promoBlock;
       await expect.soft(promoBlocks).toHaveCount(Links[collection].PromoBlocks.length);
       for (let i = 0; i < (await promoBlocks.count()); i++) {
-        if (Links[collection].PromoBlocks[i]) {
+        if (Links[collection].PromoBlocks[i] !== '') {
           await expect
             .soft(promoBlocks.nth(i))
             .toHaveAttribute('href', `${baseURL}${Links[collection].PromoBlocks[i]}`);

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -43,8 +43,13 @@ test.describe('Collection page tests', () => {
       for (let i = 0; i < (await promoBlocks.count()); i++) {
         await expect.soft(promoBlocks.nth(i)).toHaveText(collectionExpectedText.PromoBlocks[i], { useInnerText: true });
       }
-      await expect.soft(collectionPage.productsGridTitle).toHaveText(collectionExpectedText.ProductsGrid.Title);
-      await expect.soft(collectionPage.productsGridSubtitle).toHaveText(collectionExpectedText.ProductsGrid.Subtitle);
+      if (
+        collectionExpectedText.ProductsGrid.hasOwnProperty('Title') &&
+        collectionExpectedText.ProductsGrid.hasOwnProperty('Subtitle')
+      ) {
+        await expect.soft(collectionPage.productsGridTitle).toHaveText(collectionExpectedText.ProductsGrid.Title);
+        await expect.soft(collectionPage.productsGridSubtitle).toHaveText(collectionExpectedText.ProductsGrid.Subtitle);
+      }
     });
 
     test('Product item details', async () => {


### PR DESCRIPTION
While working on something else I spotted that the "Sale" collection page tests were failing the expected text content checks. This hadn't been spotted before due to the random nature of the tests i.e. they had always previously run and passed against other pages. On investigation this was a pretty simple fix - the object containing the expected text didn't have the desired properties, and shouldn't have because there is no products grid on the Sale page so I just needed to add a conditional to the relevant assertions in the failing test.

However, on reviewing the Sale page test data I spotted an error in one of the promo block links that hadn't been updated following an earlier update to the topnav test data. Looking deeper I realised there were also similar errors in other test data files so why wasn't the associated test failing? There are a couple of promo blocks on the Sale page that don't have a link behind them so when writing the relevant test I added a conditional to check the promo block link exists in the test data but this was too open-ended so undefined links (i.e. those with errors) were being skipped as well as those that were intentionally "undefined" (actually empty strings). I have tightened that check up in this PR as well as fixing the test data.