### PR TITLE
Product category filter expansion

### DIFF
--- a/tests/pages/productCategoryPage.ts
+++ b/tests/pages/productCategoryPage.ts
@@ -55,4 +55,8 @@ export default class ProductCategoryPage extends BasePage {
     const locator = ['Size', 'Color'].includes(name) ? '.swatch-attribute-options a' : 'li.item a';
     return category.locator(locator);
   }
+
+  getFilterCategoryElement(category: Locator, element: 'title' | 'content'): Locator {
+    return category.locator(`.filter-options-${element}`);
+  }
 }

--- a/tests/specs/productCategoryPage.spec.ts
+++ b/tests/specs/productCategoryPage.spec.ts
@@ -107,15 +107,11 @@ test.describe('Product category page tests', () => {
       for (let i = 0; i < numFilterCategories; i++) {
         await filterCategories.nth(i).click();
         for (let j = 0; j < numFilterCategories; j++) {
-          await expect
-            .soft(productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'title'))
-            .toHaveAttribute('aria-selected', (i === j).toString());
-          await expect
-            .soft(productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'title'))
-            .toHaveAttribute('aria-expanded', (i === j).toString());
-          await expect
-            .soft(productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'content'))
-            .toHaveAttribute('aria-hidden', (i !== j).toString());
+          const categoryTitle = productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'title');
+          const categoryContent = productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'content');
+          await expect.soft(categoryTitle).toHaveAttribute('aria-selected', (i === j).toString());
+          await expect.soft(categoryTitle).toHaveAttribute('aria-expanded', (i === j).toString());
+          await expect.soft(categoryContent).toHaveAttribute('aria-hidden', (i !== j).toString());
         }
       }
     });

--- a/tests/specs/productCategoryPage.spec.ts
+++ b/tests/specs/productCategoryPage.spec.ts
@@ -100,7 +100,8 @@ test.describe('Product category page tests', () => {
       }
     });
 
-    test('Only one filter can be expanded at a time', async () => {
+    test('Only one filter can be expanded at a time', async ({}, testInfo) => {
+      test.setTimeout(testInfo.timeout + 30000);
       const filterCategories = productCategoryPage.filterCategory;
       const numFilterCategories = Object.keys(Filters[category]).length;
       await expect.soft(filterCategories).toHaveCount(numFilterCategories);

--- a/tests/specs/productCategoryPage.spec.ts
+++ b/tests/specs/productCategoryPage.spec.ts
@@ -100,6 +100,26 @@ test.describe('Product category page tests', () => {
       }
     });
 
+    test('Only one filter can be expanded at a time', async () => {
+      const filterCategories = productCategoryPage.filterCategory;
+      const numFilterCategories = Object.keys(Filters[category]).length;
+      await expect.soft(filterCategories).toHaveCount(numFilterCategories);
+      for (let i = 0; i < numFilterCategories; i++) {
+        await filterCategories.nth(i).click();
+        for (let j = 0; j < numFilterCategories; j++) {
+          await expect
+            .soft(productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'title'))
+            .toHaveAttribute('aria-selected', (i === j).toString());
+          await expect
+            .soft(productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'title'))
+            .toHaveAttribute('aria-expanded', (i === j).toString());
+          await expect
+            .soft(productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'content'))
+            .toHaveAttribute('aria-hidden', (i !== j).toString());
+        }
+      }
+    });
+
     test('Default product item details', async () => {
       //There are a maximum of 12 products displayed by default
       const productDetails = Products[category].slice(0, 12);


### PR DESCRIPTION
Verify that only one filter category can be expanded at a time on the product category pages by asserting against various aria attributes