### PR TITLE
Add test mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 PASSWORD=''
+
+# Boolean to determine whether all pages are tested (full) or just a random page (random)
+TEST_MODE='random'

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 PASSWORD=''
 
-# Boolean to determine whether all pages are tested (full) or just a random page (random)
-TEST_MODE='random'
+# Boolean to determine whether all similar pages are tested (full) or just a single page (limited)
+TEST_MODE='limited'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,7 @@ on:
     branches: main
 env:
   PASSWORD: ${{ secrets.PASSWORD }}
+  TEST_MODE: 'full'
 jobs:
   test:
     timeout-minutes: 60

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -4,7 +4,7 @@ declare global {
   namespace NodeJS {
     interface ProcessEnv {
       PASSWORD: string;
-      TEST_MODE: 'full' | 'random';
+      TEST_MODE: 'full' | 'limited';
     }
   }
 }

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -1,0 +1,10 @@
+export {};
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      PASSWORD: string;
+      TEST_MODE: 'full' | 'random';
+    }
+  }
+}

--- a/tests/pages/productCategoryPage.ts
+++ b/tests/pages/productCategoryPage.ts
@@ -53,12 +53,12 @@ export default class ProductCategoryPage extends BasePage {
     return this.productItem.nth(productIndex).locator(element);
   }
 
-  getFilterItems(category: Locator, name: string): Locator {
+  async getFilterItems(category: Locator, name: string): Promise<Locator> {
     const locator = ['Size', 'Color'].includes(name) ? '.swatch-attribute-options a' : 'li.item a';
     return category.locator(locator);
   }
 
-  getFilterCategoryElement(category: Locator, element: 'title' | 'content'): Locator {
+  async getFilterCategoryElement(category: Locator, element: 'title' | 'content'): Promise<Locator> {
     return category.locator(`.filter-options-${element}`);
   }
 }

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -6,27 +6,20 @@ import { Colors } from '../data/pageHeader';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
-const pages =
-  process.env.TEST_MODE === 'full'
-    ? Object.keys(Collections)
-    : Array.of(Object.keys(Collections)[Math.floor(Math.random() * Object.keys(Collections).length)]);
-// for (const collection of pages) {
-for (let c = 0; c < pages.length; c++) {
-  const collection = pages[c];
+const pages = process.env.TEST_MODE === 'full' ? Object.keys(Collections) : ['Gear'];
+for (const collection of pages) {
   test.describe(`${collection} page tests zzz`, () => {
     let collectionPage: CollectionPage;
 
     test.beforeEach(async ({ page }) => {
       collectionPage = new CollectionPage(page);
       await collectionPage.open(Collections[collection]);
-      console.log(collection);
     });
 
     test.describe('Appearance tests', () => {
       // This is an example of performing visual-style testing by asserting against various element properties rather than actually using image comparison
       // The tests could be combined but I have split them here to make them easier to read and maintain
 
-      // test(`Main page elements displayed - ${collection}`, async () => {
       test('Main page elements displayed', async () => {
         await expect.soft(collectionPage.globalMessage).toBeVisible();
         await expect.soft(collectionPage.pageHeader.header).toBeVisible();
@@ -41,7 +34,6 @@ for (let c = 0; c < pages.length; c++) {
         await expect.soft(collectionPage.productItem).toHaveCount(Products[collection].length);
       });
 
-      // test(`Text content of page elements - ${collection}`, async () => {
       test('Text content of page elements', async () => {
         const collectionExpectedText = ExpectedText[collection];
         await expect.soft(collectionPage.breadcrumbsContainer).toHaveText(collectionExpectedText.Breadcrumbs);
@@ -95,7 +87,6 @@ for (let c = 0; c < pages.length; c++) {
         }
       });
 
-      // test(`Product item details - ${collection}`, async () => {
       test('Product item details', async () => {
         const productDetails = Products[collection];
         const productItems = collectionPage.productItem;
@@ -134,7 +125,6 @@ for (let c = 0; c < pages.length; c++) {
         }
       });
 
-      // test(`Corresponding topnav item highlighted - ${collection}`, async () => {
       test('Corresponding topnav item highlighted', async () => {
         const activeClass = /active/;
         const topnavLinks = await collectionPage.pageHeader.getTopnavMenuItem(collectionPage.pageHeader.topnav, 0);
@@ -155,7 +145,6 @@ for (let c = 0; c < pages.length; c++) {
     });
 
     test.describe('Link tests', () => {
-      // test(`Breadcrumb links - ${collection}`, async ({ baseURL }) => {
       test('Breadcrumb links', async ({ baseURL }) => {
         const breadcrumbs = (await collectionPage.breadcrumbsContainer.innerText()).split('  ');
         // The last breadcrumb doesn't have a link as it is the current page
@@ -166,7 +155,6 @@ for (let c = 0; c < pages.length; c++) {
         }
       });
 
-      // test(`Filter links - ${collection}`, async ({ baseURL }) => {
       test('Filter links', async ({ baseURL }) => {
         if (ShoppingOptions.hasOwnProperty(collection)) {
           const collectionShoppingOptions = ShoppingOptions[collection];
@@ -193,7 +181,6 @@ for (let c = 0; c < pages.length; c++) {
         }
       });
 
-      // test(`Promo block links - ${collection}`, async ({ baseURL }) => {
       test('Promo block links', async ({ baseURL }) => {
         const promoBlocks = collectionPage.promoBlock;
         await expect.soft(promoBlocks).toHaveCount(Links[collection].PromoBlocks.length);
@@ -206,7 +193,6 @@ for (let c = 0; c < pages.length; c++) {
         }
       });
 
-      // test(`Product links - ${collection}`, async ({ baseURL }) => {
       test('Product links', async ({ baseURL }) => {
         const productDetails = Products[collection];
         const products = collectionPage.productItem;

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -3,210 +3,232 @@ import CollectionPage from '../pages/collectionPage';
 import { Collections, ExpectedText, Links, Filters, Products, ShoppingOptions } from '../data/collectionPage';
 import { ProductItemElements } from '../pages/components/productItem';
 import { Colors } from '../data/pageHeader';
+import * as dotenv from 'dotenv';
 
-test.describe('Collection page tests', () => {
-  let collectionPage: CollectionPage;
-  let collection: string;
-  test.beforeEach(async ({ page }) => {
-    collectionPage = new CollectionPage(page);
-    collection = Object.keys(Collections)[Math.floor(Math.random() * Object.keys(Collections).length)];
-    await collectionPage.open(Collections[collection]);
-    console.log(collection);
-  });
+dotenv.config();
+const pages =
+  process.env.TEST_MODE === 'full'
+    ? Object.keys(Collections)
+    : Array.of(Object.keys(Collections)[Math.floor(Math.random() * Object.keys(Collections).length)]);
+// for (const collection of pages) {
+for (let c = 0; c < pages.length; c++) {
+  const collection = pages[c];
+  test.describe(`${collection} page tests zzz`, () => {
+    let collectionPage: CollectionPage;
 
-  test.describe('Appearance tests', () => {
-    // This is an example of performing visual-style testing by asserting against various element properties rather than actually using image comparison
-    // The tests could be combined but I have split them here to make them easier to read and maintain
-
-    test('Main page elements displayed', async () => {
-      await expect.soft(collectionPage.globalMessage).toBeVisible();
-      await expect.soft(collectionPage.pageHeader.header).toBeVisible();
-      await expect.soft(collectionPage.pageHeader.topnav).toBeVisible();
-      await expect.soft(collectionPage.breadcrumbsContainer).toBeVisible();
-      await expect.soft(collectionPage.primarySidebar).toBeVisible();
-      await expect.soft(collectionPage.secondarySidebar).toBeVisible();
-      if (Products[collection].length) await expect.soft(collectionPage.productsGrid).toBeVisible();
-      await expect.soft(collectionPage.pageFooter.footer).toBeVisible();
-      await expect.soft(collectionPage.pageFooter.copyrightFooter).toBeVisible();
-
-      await expect.soft(collectionPage.promoBlock).toHaveCount(ExpectedText[collection].PromoBlocks.length);
-      await expect.soft(collectionPage.productItem).toHaveCount(Products[collection].length);
+    test.beforeEach(async ({ page }) => {
+      collectionPage = new CollectionPage(page);
+      await collectionPage.open(Collections[collection]);
+      console.log(collection);
     });
 
-    test('Text content of page elements', async () => {
-      const collectionExpectedText = ExpectedText[collection];
-      await expect.soft(collectionPage.breadcrumbsContainer).toHaveText(collectionExpectedText.Breadcrumbs);
-      await expect.soft(collectionPage.pageTitle).toHaveText(collectionExpectedText.Title);
+    test.describe('Appearance tests', () => {
+      // This is an example of performing visual-style testing by asserting against various element properties rather than actually using image comparison
+      // The tests could be combined but I have split them here to make them easier to read and maintain
 
-      if (ShoppingOptions.hasOwnProperty(collection)) {
-        const collectionShoppingOptions = ShoppingOptions[collection];
-        await expect.soft(collectionPage.shoppingOptionsTitle).toHaveText(collectionShoppingOptions.title);
-        await expect.soft(collectionPage.shoppingOptionsSubtitle).toHaveText(collectionShoppingOptions.subtitle);
-        const categories = await collectionPage.getFilterCategories(collectionPage.shoppingOptionsList);
-        await expect.soft(categories).toHaveCount(collectionShoppingOptions.categories.length);
-        for (let i = 0; i < collectionShoppingOptions.categories.length; i++) {
-          const expectedText = `${collectionShoppingOptions.categories[i].title} ${collectionShoppingOptions.categories[i].count}`;
-          await expect.soft(categories.nth(i).locator('..')).toHaveText(expectedText, { useInnerText: true });
-        }
-      }
+      // test(`Main page elements displayed - ${collection}`, async () => {
+      test('Main page elements displayed', async () => {
+        await expect.soft(collectionPage.globalMessage).toBeVisible();
+        await expect.soft(collectionPage.pageHeader.header).toBeVisible();
+        await expect.soft(collectionPage.pageHeader.topnav).toBeVisible();
+        await expect.soft(collectionPage.breadcrumbsContainer).toBeVisible();
+        await expect.soft(collectionPage.primarySidebar).toBeVisible();
+        await expect.soft(collectionPage.secondarySidebar).toBeVisible();
+        if (Products[collection].length) await expect.soft(collectionPage.productsGrid).toBeVisible();
+        await expect.soft(collectionPage.pageFooter.footer).toBeVisible();
+        await expect.soft(collectionPage.pageFooter.copyrightFooter).toBeVisible();
+        await expect.soft(collectionPage.promoBlock).toHaveCount(ExpectedText[collection].PromoBlocks.length);
+        await expect.soft(collectionPage.productItem).toHaveCount(Products[collection].length);
+      });
 
-      const collectionFilters = Filters[collection];
-      const filterLists = collectionPage.filterList;
-      await expect.soft(filterLists).toHaveCount(collectionFilters.length);
-      for (let i = 0; i < collectionFilters.length; i++) {
-        await expect.soft(collectionPage.filterTitle.nth(i)).toHaveText(collectionFilters[i].title);
-        const filterCategories = await collectionPage.getFilterCategories(filterLists.nth(i));
-        await expect.soft(filterCategories).toHaveCount(collectionFilters[i].categories.length);
-        for (let j = 0; j < collectionFilters[i].categories.length; j++) {
-          await expect.soft(filterCategories.nth(j)).toHaveText(collectionFilters[i].categories[j].title);
-        }
-      }
+      // test(`Text content of page elements - ${collection}`, async () => {
+      test('Text content of page elements', async () => {
+        const collectionExpectedText = ExpectedText[collection];
+        await expect.soft(collectionPage.breadcrumbsContainer).toHaveText(collectionExpectedText.Breadcrumbs);
+        await expect.soft(collectionPage.pageTitle).toHaveText(collectionExpectedText.Title);
 
-      const sidebarBlocks = collectionPage.sidebarBlock;
-      await expect.soft(sidebarBlocks).toHaveCount(ExpectedText.SidebarBlocks.length);
-      for (let i = 0; i < ExpectedText.SidebarBlocks.length; i++) {
-        await expect.soft(sidebarBlocks.nth(i)).toHaveText(ExpectedText.SidebarBlocks[i], { useInnerText: true });
-      }
-
-      const promoBlocks = collectionPage.promoBlock;
-      await expect.soft(promoBlocks).toHaveCount(collectionExpectedText.PromoBlocks.length);
-      for (let i = 0; i < collectionExpectedText.PromoBlocks.length; i++) {
-        await expect.soft(promoBlocks.nth(i)).toHaveText(collectionExpectedText.PromoBlocks[i], { useInnerText: true });
-      }
-      if (
-        collectionExpectedText.ProductsGrid.hasOwnProperty('Title') &&
-        collectionExpectedText.ProductsGrid.hasOwnProperty('Subtitle')
-      ) {
-        await expect.soft(collectionPage.productsGridTitle).toHaveText(collectionExpectedText.ProductsGrid.Title);
-        await expect.soft(collectionPage.productsGridSubtitle).toHaveText(collectionExpectedText.ProductsGrid.Subtitle);
-      }
-    });
-
-    test('Product item details', async () => {
-      const productDetails = Products[collection];
-      const productItems = collectionPage.productItem;
-      await expect.soft(productItems).toHaveCount(productDetails.length);
-      for (let i = 0; i < productDetails.length; i++) {
-        await expect
-          .soft(collectionPage.getProductItemElement(i, ProductItemElements.Name))
-          .toHaveText(productDetails[i].title);
-        if (productDetails[i].rating) {
-          await expect
-            .soft(collectionPage.getProductItemElement(i, ProductItemElements.Rating))
-            .toHaveText(productDetails[i].rating!);
-        }
-        if (productDetails[i].reviews) {
-          await expect
-            .soft(collectionPage.getProductItemElement(i, ProductItemElements.Reviews))
-            .toHaveText(productDetails[i].reviews!);
-        }
-        await expect
-          .soft(collectionPage.getProductItemElement(i, ProductItemElements.Price).first())
-          .toHaveText(productDetails[i].price);
-        if (productDetails[i].sizes) {
-          const sizes = collectionPage.getProductItemElement(i, ProductItemElements.Sizes);
-          await expect.soft(sizes).toHaveCount(productDetails[i].sizes!.length);
-          for (let j = 0; j < productDetails[i].sizes!.length; j++) {
-            await expect.soft(sizes.nth(j)).toHaveText(productDetails[i].sizes![j]);
+        if (ShoppingOptions.hasOwnProperty(collection)) {
+          const collectionShoppingOptions = ShoppingOptions[collection];
+          await expect.soft(collectionPage.shoppingOptionsTitle).toHaveText(collectionShoppingOptions.title);
+          await expect.soft(collectionPage.shoppingOptionsSubtitle).toHaveText(collectionShoppingOptions.subtitle);
+          const categories = await collectionPage.getFilterCategories(collectionPage.shoppingOptionsList);
+          await expect.soft(categories).toHaveCount(collectionShoppingOptions.categories.length);
+          for (let i = 0; i < collectionShoppingOptions.categories.length; i++) {
+            const expectedText = `${collectionShoppingOptions.categories[i].title} ${collectionShoppingOptions.categories[i].count}`;
+            await expect.soft(categories.nth(i).locator('..')).toHaveText(expectedText, { useInnerText: true });
           }
         }
-        if (productDetails[i].colors) {
-          const colors = collectionPage.getProductItemElement(i, ProductItemElements.Colors);
-          await expect.soft(colors).toHaveCount(productDetails[i].colors!.length);
-          for (let j = 0; j < productDetails[i].colors!.length; j++) {
-            await expect.soft(colors.nth(j)).toHaveCSS('background-color', productDetails[i].colors![j]);
+
+        const collectionFilters = Filters[collection];
+        const filterLists = collectionPage.filterList;
+        await expect.soft(filterLists).toHaveCount(collectionFilters.length);
+        for (let i = 0; i < collectionFilters.length; i++) {
+          await expect.soft(collectionPage.filterTitle.nth(i)).toHaveText(collectionFilters[i].title);
+          const filterCategories = await collectionPage.getFilterCategories(filterLists.nth(i));
+          await expect.soft(filterCategories).toHaveCount(collectionFilters[i].categories.length);
+          for (let j = 0; j < collectionFilters[i].categories.length; j++) {
+            await expect.soft(filterCategories.nth(j)).toHaveText(collectionFilters[i].categories[j].title);
           }
         }
-      }
-    });
 
-    test('Corresponding topnav item highlighted', async () => {
-      const activeClass = /active/;
-      const topnavLinks = await collectionPage.pageHeader.getTopnavMenuItem(collectionPage.pageHeader.topnav, 0);
-      await expect.soft(topnavLinks).toHaveCount(Object.keys(Collections).length);
-      for (let i = 0; i < Object.keys(Collections).length; i++) {
-        const link = await collectionPage.pageHeader.getTopnavMenuLink(topnavLinks.nth(i));
-        if ((await link.textContent()) === collection.replace('WhatsNew', "What's New")) {
-          await expect.soft(topnavLinks.nth(i)).toHaveClass(activeClass);
-          await expect.soft(link).toHaveCSS('border-color', Colors.Border.Active);
-          await expect.soft(link).toHaveCSS('border-width', '0px 0px 3px');
-        } else {
-          await expect.soft(topnavLinks.nth(i)).not.toHaveClass(activeClass);
-          await expect.soft(link).toHaveCSS('border-color', Colors.Border.Inactive);
-          await expect.soft(link).toHaveCSS('border-width', '0px');
+        const sidebarBlocks = collectionPage.sidebarBlock;
+        await expect.soft(sidebarBlocks).toHaveCount(ExpectedText.SidebarBlocks.length);
+        for (let i = 0; i < ExpectedText.SidebarBlocks.length; i++) {
+          await expect.soft(sidebarBlocks.nth(i)).toHaveText(ExpectedText.SidebarBlocks[i], { useInnerText: true });
         }
-      }
-    });
-  });
 
-  test.describe('Link tests', () => {
-    test('Breadcrumb links', async ({ baseURL }) => {
-      const breadcrumbs = (await collectionPage.breadcrumbsContainer.innerText()).split('  ');
-      // The last breadcrumb doesn't have a link as it is the current page
-      for (let i = 0; i < breadcrumbs.length - 1; i++) {
-        await expect
-          .soft(collectionPage.breadcrumb.nth(i))
-          .toHaveAttribute('href', `${baseURL}${Links[collection].Breadcrumbs[breadcrumbs[i]]}`);
-      }
-    });
-
-    test('Filter links', async ({ baseURL }) => {
-      if (ShoppingOptions.hasOwnProperty(collection)) {
-        const collectionShoppingOptions = ShoppingOptions[collection];
-        const categories = await collectionPage.getFilterCategories(collectionPage.shoppingOptionsList);
-        await expect.soft(categories).toHaveCount(collectionShoppingOptions.categories.length);
-        for (let i = 0; i < collectionShoppingOptions.categories.length; i++) {
-          await expect
-            .soft(categories.nth(i))
-            .toHaveAttribute('href', `${baseURL}${collectionShoppingOptions.categories[i].link}`);
-        }
-      }
-
-      const collectionFilters = Filters[collection];
-      const filterLists = collectionPage.filterList;
-      await expect.soft(filterLists).toHaveCount(collectionFilters.length);
-      for (let i = 0; i < collectionFilters.length; i++) {
-        const filterCategories = await collectionPage.getFilterCategories(filterLists.nth(i));
-        await expect.soft(filterCategories).toHaveCount(collectionFilters[i].categories.length);
-        for (let j = 0; j < collectionFilters[i].categories.length; j++) {
-          await expect
-            .soft(filterCategories.nth(j))
-            .toHaveAttribute('href', `${baseURL}${collectionFilters[i].categories[j].link}`);
-        }
-      }
-    });
-
-    test('Promo block links', async ({ baseURL }) => {
-      const promoBlocks = collectionPage.promoBlock;
-      await expect.soft(promoBlocks).toHaveCount(Links[collection].PromoBlocks.length);
-      for (let i = 0; i < Links[collection].PromoBlocks.length; i++) {
-        if (Links[collection].PromoBlocks[i] !== '') {
+        const promoBlocks = collectionPage.promoBlock;
+        await expect.soft(promoBlocks).toHaveCount(collectionExpectedText.PromoBlocks.length);
+        for (let i = 0; i < collectionExpectedText.PromoBlocks.length; i++) {
           await expect
             .soft(promoBlocks.nth(i))
-            .toHaveAttribute('href', `${baseURL}${Links[collection].PromoBlocks[i]}`);
+            .toHaveText(collectionExpectedText.PromoBlocks[i], { useInnerText: true });
         }
-      }
+        if (
+          collectionExpectedText.ProductsGrid.hasOwnProperty('Title') &&
+          collectionExpectedText.ProductsGrid.hasOwnProperty('Subtitle')
+        ) {
+          await expect.soft(collectionPage.productsGridTitle).toHaveText(collectionExpectedText.ProductsGrid.Title);
+          await expect
+            .soft(collectionPage.productsGridSubtitle)
+            .toHaveText(collectionExpectedText.ProductsGrid.Subtitle);
+        }
+      });
+
+      // test(`Product item details - ${collection}`, async () => {
+      test('Product item details', async () => {
+        const productDetails = Products[collection];
+        const productItems = collectionPage.productItem;
+        await expect.soft(productItems).toHaveCount(productDetails.length);
+        for (let i = 0; i < productDetails.length; i++) {
+          await expect
+            .soft(collectionPage.getProductItemElement(i, ProductItemElements.Name))
+            .toHaveText(productDetails[i].title);
+          if (productDetails[i].rating) {
+            await expect
+              .soft(collectionPage.getProductItemElement(i, ProductItemElements.Rating))
+              .toHaveText(productDetails[i].rating!);
+          }
+          if (productDetails[i].reviews) {
+            await expect
+              .soft(collectionPage.getProductItemElement(i, ProductItemElements.Reviews))
+              .toHaveText(productDetails[i].reviews!);
+          }
+          await expect
+            .soft(collectionPage.getProductItemElement(i, ProductItemElements.Price).first())
+            .toHaveText(productDetails[i].price);
+          if (productDetails[i].sizes) {
+            const sizes = collectionPage.getProductItemElement(i, ProductItemElements.Sizes);
+            await expect.soft(sizes).toHaveCount(productDetails[i].sizes!.length);
+            for (let j = 0; j < productDetails[i].sizes!.length; j++) {
+              await expect.soft(sizes.nth(j)).toHaveText(productDetails[i].sizes![j]);
+            }
+          }
+          if (productDetails[i].colors) {
+            const colors = collectionPage.getProductItemElement(i, ProductItemElements.Colors);
+            await expect.soft(colors).toHaveCount(productDetails[i].colors!.length);
+            for (let j = 0; j < productDetails[i].colors!.length; j++) {
+              await expect.soft(colors.nth(j)).toHaveCSS('background-color', productDetails[i].colors![j]);
+            }
+          }
+        }
+      });
+
+      // test(`Corresponding topnav item highlighted - ${collection}`, async () => {
+      test('Corresponding topnav item highlighted', async () => {
+        const activeClass = /active/;
+        const topnavLinks = await collectionPage.pageHeader.getTopnavMenuItem(collectionPage.pageHeader.topnav, 0);
+        await expect.soft(topnavLinks).toHaveCount(Object.keys(Collections).length);
+        for (let i = 0; i < Object.keys(Collections).length; i++) {
+          const link = await collectionPage.pageHeader.getTopnavMenuLink(topnavLinks.nth(i));
+          if ((await link.textContent()) === collection.replace('WhatsNew', "What's New")) {
+            await expect.soft(topnavLinks.nth(i)).toHaveClass(activeClass);
+            await expect.soft(link).toHaveCSS('border-color', Colors.Border.Active);
+            await expect.soft(link).toHaveCSS('border-width', '0px 0px 3px');
+          } else {
+            await expect.soft(topnavLinks.nth(i)).not.toHaveClass(activeClass);
+            await expect.soft(link).toHaveCSS('border-color', Colors.Border.Inactive);
+            await expect.soft(link).toHaveCSS('border-width', '0px');
+          }
+        }
+      });
     });
 
-    test('Product links', async ({ baseURL }) => {
-      const productDetails = Products[collection];
-      const products = collectionPage.productItem;
-      await expect.soft(products).toHaveCount(productDetails.length);
-      for (let i = 0; i < productDetails.length; i++) {
-        await expect
-          .soft(collectionPage.getProductItemElement(i, ProductItemElements.PhotoLink))
-          .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
-        await expect
-          .soft(collectionPage.getProductItemElement(i, ProductItemElements.NameLink))
-          .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
-        if (productDetails[i].reviews) {
+    test.describe('Link tests', () => {
+      // test(`Breadcrumb links - ${collection}`, async ({ baseURL }) => {
+      test('Breadcrumb links', async ({ baseURL }) => {
+        const breadcrumbs = (await collectionPage.breadcrumbsContainer.innerText()).split('  ');
+        // The last breadcrumb doesn't have a link as it is the current page
+        for (let i = 0; i < breadcrumbs.length - 1; i++) {
           await expect
-            .soft(collectionPage.getProductItemElement(i, ProductItemElements.ReviewsLink))
-            .toHaveAttribute('href', `${baseURL}${productDetails[i].link}#reviews`);
-        } else {
-          await expect.soft(collectionPage.getProductItemElement(i, ProductItemElements.ReviewsLink)).not.toBeVisible();
+            .soft(collectionPage.breadcrumb.nth(i))
+            .toHaveAttribute('href', `${baseURL}${Links[collection].Breadcrumbs[breadcrumbs[i]]}`);
         }
-      }
+      });
+
+      // test(`Filter links - ${collection}`, async ({ baseURL }) => {
+      test('Filter links', async ({ baseURL }) => {
+        if (ShoppingOptions.hasOwnProperty(collection)) {
+          const collectionShoppingOptions = ShoppingOptions[collection];
+          const categories = await collectionPage.getFilterCategories(collectionPage.shoppingOptionsList);
+          await expect.soft(categories).toHaveCount(collectionShoppingOptions.categories.length);
+          for (let i = 0; i < collectionShoppingOptions.categories.length; i++) {
+            await expect
+              .soft(categories.nth(i))
+              .toHaveAttribute('href', `${baseURL}${collectionShoppingOptions.categories[i].link}`);
+          }
+        }
+
+        const collectionFilters = Filters[collection];
+        const filterLists = collectionPage.filterList;
+        await expect.soft(filterLists).toHaveCount(collectionFilters.length);
+        for (let i = 0; i < collectionFilters.length; i++) {
+          const filterCategories = await collectionPage.getFilterCategories(filterLists.nth(i));
+          await expect.soft(filterCategories).toHaveCount(collectionFilters[i].categories.length);
+          for (let j = 0; j < collectionFilters[i].categories.length; j++) {
+            await expect
+              .soft(filterCategories.nth(j))
+              .toHaveAttribute('href', `${baseURL}${collectionFilters[i].categories[j].link}`);
+          }
+        }
+      });
+
+      // test(`Promo block links - ${collection}`, async ({ baseURL }) => {
+      test('Promo block links', async ({ baseURL }) => {
+        const promoBlocks = collectionPage.promoBlock;
+        await expect.soft(promoBlocks).toHaveCount(Links[collection].PromoBlocks.length);
+        for (let i = 0; i < Links[collection].PromoBlocks.length; i++) {
+          if (Links[collection].PromoBlocks[i] !== '') {
+            await expect
+              .soft(promoBlocks.nth(i))
+              .toHaveAttribute('href', `${baseURL}${Links[collection].PromoBlocks[i]}`);
+          }
+        }
+      });
+
+      // test(`Product links - ${collection}`, async ({ baseURL }) => {
+      test('Product links', async ({ baseURL }) => {
+        const productDetails = Products[collection];
+        const products = collectionPage.productItem;
+        await expect.soft(products).toHaveCount(productDetails.length);
+        for (let i = 0; i < productDetails.length; i++) {
+          await expect
+            .soft(collectionPage.getProductItemElement(i, ProductItemElements.PhotoLink))
+            .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
+          await expect
+            .soft(collectionPage.getProductItemElement(i, ProductItemElements.NameLink))
+            .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
+          if (productDetails[i].reviews) {
+            await expect
+              .soft(collectionPage.getProductItemElement(i, ProductItemElements.ReviewsLink))
+              .toHaveAttribute('href', `${baseURL}${productDetails[i].link}#reviews`);
+          } else {
+            await expect
+              .soft(collectionPage.getProductItemElement(i, ProductItemElements.ReviewsLink))
+              .not.toBeVisible();
+          }
+        }
+      });
     });
   });
-});
+}

--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -8,7 +8,7 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 const pages = process.env.TEST_MODE === 'full' ? Object.keys(Collections) : ['Gear'];
 for (const collection of pages) {
-  test.describe(`${collection} page tests zzz`, () => {
+  test.describe(`${collection} page tests`, () => {
     let collectionPage: CollectionPage;
 
     test.beforeEach(async ({ page }) => {

--- a/tests/specs/productCategoryPage.spec.ts
+++ b/tests/specs/productCategoryPage.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '../data/productCategoryPage';
 import { ProductItemElements } from '../pages/components/productItem';
 import { Colors, Links as HeaderLinks, MenuItemText, SubMenuKeys } from '../data/pageHeader';
+import * as dotenv from 'dotenv';
 
 async function verifyMenuItemHighlighting(link: Locator, position?: 'left' | 'bottom') {
   if (!position) {
@@ -22,250 +23,264 @@ async function verifyMenuItemHighlighting(link: Locator, position?: 'left' | 'bo
   }
 }
 
-test.describe('Product category page tests', () => {
-  let productCategoryPage: ProductCategoryPage;
-  let lvl0Category: string;
-  let lvl1Category: string;
-  let lvl2Category: string;
-  let category: string;
-  let url: string;
-  test.beforeEach(async ({ page }) => {
-    productCategoryPage = new ProductCategoryPage(page);
-    lvl0Category = Object.keys(ProductCategories)[Math.floor(Math.random() * Object.keys(ProductCategories).length)];
-    lvl1Category = Object.keys(ProductCategories[lvl0Category])[
-      Math.floor(Math.random() * Object.keys(ProductCategories[lvl0Category]).length)
-    ];
-    lvl2Category = lvl1Category.endsWith('SubMenu')
-      ? Object.keys(ProductCategories[lvl0Category][lvl1Category])[
-          Math.floor(Math.random() * Object.keys(ProductCategories[lvl0Category][lvl1Category]).length)
-        ]
-      : '';
-    category = lvl2Category ? `${lvl0Category}${lvl2Category}` : `${lvl0Category}${lvl1Category}`;
-    console.log(category);
-    url = lvl2Category
-      ? ProductCategories[lvl0Category][lvl1Category][lvl2Category]
-      : ProductCategories[lvl0Category][lvl1Category];
-    await productCategoryPage.open(url);
-  });
+dotenv.config();
+const lvl0Categories = process.env.TEST_MODE === 'limited' ? ['Women'] : Object.keys(ProductCategories);
+for (const lvl0Category of lvl0Categories) {
+  const lvl1Categories = process.env.TEST_MODE === 'limited' ? ['Tops'] : Object.keys(ProductCategories[lvl0Category]);
+  for (const lvl1Category of lvl1Categories) {
+    const lvl2Categories =
+      process.env.TEST_MODE === 'limited'
+        ? ['']
+        : lvl1Category.endsWith('SubMenu')
+          ? Object.keys(ProductCategories[lvl0Category][lvl1Category])
+          : [''];
+    for (const lvl2Category of lvl2Categories) {
+      const category = lvl2Category ? `${lvl0Category}${lvl2Category}` : `${lvl0Category}${lvl1Category}`;
+      const pageName = lvl2Category
+        ? `${lvl0Category} > ${lvl1Category.replace('SubMenu', '')} > ${lvl2Category}`
+        : `${lvl0Category} > ${lvl1Category}`;
+      test.describe(`${pageName} page tests`, () => {
+        let productCategoryPage: ProductCategoryPage;
+        let url: string;
+        test.beforeEach(async ({ page }) => {
+          productCategoryPage = new ProductCategoryPage(page);
+          url = lvl2Category
+            ? ProductCategories[lvl0Category][lvl1Category][lvl2Category]
+            : ProductCategories[lvl0Category][lvl1Category];
+          await productCategoryPage.open(url);
+        });
 
-  test.describe('Appearance tests', () => {
-    // This is an example of performing visual-style testing by asserting against various element properties rather than actually using image comparison
-    // The tests could be combined but I have split them here to make them easier to read and maintain
+        test.describe('Appearance tests', () => {
+          // This is an example of performing visual-style testing by asserting against various element properties rather than actually using image comparison
+          // The tests could be combined but I have split them here to make them easier to read and maintain
 
-    test('Main page elements displayed', async () => {
-      await expect.soft(productCategoryPage.globalMessage).toBeVisible();
-      await expect.soft(productCategoryPage.pageHeader.header).toBeVisible();
-      await expect.soft(productCategoryPage.pageHeader.topnav).toBeVisible();
-      await expect.soft(productCategoryPage.breadcrumbsContainer).toBeVisible();
-      await expect.soft(productCategoryPage.filters).toBeVisible();
-      await expect.soft(productCategoryPage.sidebar).toBeVisible();
-      await expect.soft(productCategoryPage.displayToolbar).toBeVisible();
-      await expect.soft(productCategoryPage.productsGrid).toBeVisible();
-      await expect.soft(productCategoryPage.paginationToolbar).toBeVisible();
-      await expect.soft(productCategoryPage.pageFooter.footer).toBeVisible();
-      await expect.soft(productCategoryPage.pageFooter.copyrightFooter).toBeVisible();
-    });
+          test('Main page elements displayed', async () => {
+            await expect.soft(productCategoryPage.globalMessage).toBeVisible();
+            await expect.soft(productCategoryPage.pageHeader.header).toBeVisible();
+            await expect.soft(productCategoryPage.pageHeader.topnav).toBeVisible();
+            await expect.soft(productCategoryPage.breadcrumbsContainer).toBeVisible();
+            await expect.soft(productCategoryPage.filters).toBeVisible();
+            await expect.soft(productCategoryPage.sidebar).toBeVisible();
+            await expect.soft(productCategoryPage.displayToolbar).toBeVisible();
+            await expect.soft(productCategoryPage.productsGrid).toBeVisible();
+            await expect.soft(productCategoryPage.paginationToolbar).toBeVisible();
+            await expect.soft(productCategoryPage.pageFooter.footer).toBeVisible();
+            await expect.soft(productCategoryPage.pageFooter.copyrightFooter).toBeVisible();
+          });
 
-    test('Text content of main page elements', async () => {
-      const categoryExpectedText = ExpectedText[category];
-      await expect.soft(productCategoryPage.breadcrumbsContainer).toHaveText(categoryExpectedText.Breadcrumbs);
-      await expect.soft(productCategoryPage.pageTitle).toHaveText(categoryExpectedText.Title);
-      const sidebarBlocks = productCategoryPage.sidebarBlock;
-      await expect.soft(sidebarBlocks).toHaveCount(ExpectedText.SidebarBlocks.length);
-      for (let i = 0; i < ExpectedText.SidebarBlocks.length; i++) {
-        await expect.soft(sidebarBlocks.nth(i)).toHaveText(ExpectedText.SidebarBlocks[i], { useInnerText: true });
-      }
-      await expect
-        .soft(productCategoryPage.productCount)
-        .toHaveText(categoryExpectedText.ProductCount, { useInnerText: true });
-    });
+          test('Text content of main page elements', async () => {
+            const categoryExpectedText = ExpectedText[category];
+            await expect.soft(productCategoryPage.breadcrumbsContainer).toHaveText(categoryExpectedText.Breadcrumbs);
+            await expect.soft(productCategoryPage.pageTitle).toHaveText(categoryExpectedText.Title);
+            const sidebarBlocks = productCategoryPage.sidebarBlock;
+            await expect.soft(sidebarBlocks).toHaveCount(ExpectedText.SidebarBlocks.length);
+            for (let i = 0; i < ExpectedText.SidebarBlocks.length; i++) {
+              await expect.soft(sidebarBlocks.nth(i)).toHaveText(ExpectedText.SidebarBlocks[i], { useInnerText: true });
+            }
+            await expect
+              .soft(productCategoryPage.productCount)
+              .toHaveText(categoryExpectedText.ProductCount, { useInnerText: true });
+          });
 
-    // Filters split into separate test to avoid making the above test really hard to read (& develop)
-    test('Text content of filters', async () => {
-      await expect.soft(productCategoryPage.filtersTitle).toHaveText(ExpectedText.FiltersTitle);
-      const filterCategories = productCategoryPage.filterCategory;
-      const expectedFilters = Filters[category];
-      await expect.soft(filterCategories).toHaveCount(Object.keys(expectedFilters).length);
-      for (let i = 0; i < Object.keys(expectedFilters).length; i++) {
-        const categoryName = FilterCategoryName(await filterCategories.nth(i).innerText());
-        expect.soft(categoryName).toEqual(Object.keys(expectedFilters)[i]);
-        const filterItems = productCategoryPage.getFilterItems(filterCategories.nth(i), categoryName);
-        await expect.soft(filterItems).toHaveCount(expectedFilters[categoryName].length);
-        for (let j = 0; j < expectedFilters[categoryName].length; j++) {
-          const expectedTitle = expectedFilters[categoryName][j].title;
-          const expectedText = `${expectedFilters[categoryName][j].title} ${expectedFilters[categoryName][j].count}\n item`;
-          if (['Size', 'Color'].includes(categoryName)) {
-            await expect.soft(filterItems.nth(j)).toHaveAttribute('aria-label', expectedTitle);
-          } else {
-            await expect.soft(filterItems.nth(j)).toHaveText(expectedText, {
-              useInnerText: true,
-            });
-          }
-        }
-      }
-    });
-
-    test('Only one filter can be expanded at a time', async ({}, testInfo) => {
-      test.setTimeout(testInfo.timeout + 30000);
-      const filterCategories = productCategoryPage.filterCategory;
-      const numFilterCategories = Object.keys(Filters[category]).length;
-      await expect.soft(filterCategories).toHaveCount(numFilterCategories);
-      for (let i = 0; i < numFilterCategories; i++) {
-        await filterCategories.nth(i).click();
-        for (let j = 0; j < numFilterCategories; j++) {
-          const categoryTitle = productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'title');
-          const categoryContent = productCategoryPage.getFilterCategoryElement(filterCategories.nth(j), 'content');
-          await expect.soft(categoryTitle).toHaveAttribute('aria-selected', (i === j).toString());
-          await expect.soft(categoryTitle).toHaveAttribute('aria-expanded', (i === j).toString());
-          await expect.soft(categoryContent).toHaveAttribute('aria-hidden', (i !== j).toString());
-        }
-      }
-    });
-
-    test('Default product item details', async () => {
-      //There are a maximum of 12 products displayed by default
-      const productDetails = Products[category].slice(0, 12);
-      const productItems = productCategoryPage.productItem;
-      await expect.soft(productItems).toHaveCount(productDetails.length);
-      for (let i = 0; i < productDetails.length; i++) {
-        await expect
-          .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.Name))
-          .toHaveText(productDetails[i].title);
-        if (productDetails[i].rating) {
-          await expect
-            .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.Rating))
-            .toHaveText(productDetails[i].rating!);
-        }
-        if (productDetails[i].reviews) {
-          await expect
-            .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.Reviews))
-            .toHaveText(productDetails[i].reviews!);
-        }
-        await expect
-          .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.Price).first())
-          .toHaveText(productDetails[i].price);
-        if (productDetails[i].sizes) {
-          const sizes = productCategoryPage.getProductItemElement(i, ProductItemElements.Sizes);
-          await expect.soft(sizes).toHaveCount(productDetails[i].sizes!.length);
-          for (let j = 0; j < productDetails[i].sizes!.length; j++) {
-            await expect.soft(sizes.nth(j)).toHaveText(productDetails[i].sizes![j]);
-          }
-        }
-        if (productDetails[i].colors) {
-          const colors = productCategoryPage.getProductItemElement(i, ProductItemElements.Colors);
-          await expect.soft(colors).toHaveCount(productDetails[i].colors!.length);
-          for (let j = 0; j < productDetails[i].colors!.length; j++) {
-            await expect.soft(colors.nth(j)).toHaveCSS('background-color', productDetails[i].colors![j]);
-          }
-        }
-      }
-    });
-
-    test('Corresponding topnav item highlighted', async () => {
-      const pageHeader = productCategoryPage.pageHeader;
-      const lvl0MenuItems = await pageHeader.getTopnavMenuItem(pageHeader.topnav, 0);
-      const lvl0Keys = SubMenuKeys(HeaderLinks.Topnav);
-      await expect.soft(lvl0MenuItems).toHaveCount(lvl0Keys.length);
-      for (let i = 0; i < lvl0Keys.length; i++) {
-        const link = await pageHeader.getTopnavMenuLink(lvl0MenuItems.nth(i));
-        if ((await MenuItemText(link)) === lvl0Category) {
-          await verifyMenuItemHighlighting(link, 'bottom');
-
-          const lvl1MenuItems = await pageHeader.getTopnavMenuItem(lvl0MenuItems.nth(i), 1);
-          const lvl1Keys = SubMenuKeys(HeaderLinks.Topnav[`${lvl0Category}SubMenu`]);
-          await expect.soft(lvl1MenuItems).toHaveCount(lvl1Keys.length);
-
-          for (let j = 0; j < lvl1Keys.length; j++) {
-            const link = await pageHeader.getTopnavMenuLink(lvl1MenuItems.nth(j));
-            const lvl2MenuItems = await pageHeader.getTopnavMenuItem(lvl1MenuItems.nth(j), 2);
-            if ((await MenuItemText(link)) === lvl1Category.replace('SubMenu', '')) {
-              if (url.split('/').length === 3) {
-                // Lvl1 category e.g. Women > Tops highlighted in topnav but no child menu items highlighted
-                await verifyMenuItemHighlighting(link, 'left');
-
-                if (Object.keys(HeaderLinks.Topnav[`${lvl0Category}SubMenu`]).includes(`${lvl1Category}SubMenu`)) {
-                  const lvl2Keys = Object.keys(HeaderLinks.Topnav[`${lvl0Category}SubMenu`][`${lvl1Category}SubMenu`]);
-                  await expect.soft(lvl2MenuItems).toHaveCount(lvl2Keys.length);
-                  for (let k = 0; k < lvl2Keys.length; k++) {
-                    const link = await pageHeader.getTopnavMenuLink(lvl2MenuItems.nth(k));
-                    await verifyMenuItemHighlighting(link);
-                  }
+          // Filters split into separate test to avoid making the above test really hard to read (& develop)
+          test('Text content of filters', async () => {
+            await expect.soft(productCategoryPage.filtersTitle).toHaveText(ExpectedText.FiltersTitle);
+            const filterCategories = productCategoryPage.filterCategory;
+            const expectedFilters = Filters[category];
+            await expect.soft(filterCategories).toHaveCount(Object.keys(expectedFilters).length);
+            for (let i = 0; i < Object.keys(expectedFilters).length; i++) {
+              const categoryName = FilterCategoryName(await filterCategories.nth(i).innerText());
+              expect.soft(categoryName).toEqual(Object.keys(expectedFilters)[i]);
+              const filterItems = await productCategoryPage.getFilterItems(filterCategories.nth(i), categoryName);
+              await expect.soft(filterItems).toHaveCount(expectedFilters[categoryName].length);
+              for (let j = 0; j < expectedFilters[categoryName].length; j++) {
+                const expectedTitle = expectedFilters[categoryName][j].title;
+                const expectedText = `${expectedFilters[categoryName][j].title} ${expectedFilters[categoryName][j].count}\n item`;
+                if (['Size', 'Color'].includes(categoryName)) {
+                  await expect.soft(filterItems.nth(j)).toHaveAttribute('aria-label', expectedTitle);
+                } else {
+                  await expect.soft(filterItems.nth(j)).toHaveText(expectedText, {
+                    useInnerText: true,
+                  });
                 }
               }
-              if (url.split('/').length === 4) {
-                // Lvl2 category e.g. Women > Tops > Jackets highlighted in topnav but parent menu item not highlighted
-                await verifyMenuItemHighlighting(link);
+            }
+          });
 
-                const lvl2Keys = Object.keys(HeaderLinks.Topnav[`${lvl0Category}SubMenu`][lvl1Category]);
-                await expect.soft(lvl2MenuItems).toHaveCount(lvl2Keys.length);
-                for (let k = 0; k < lvl2Keys.length; k++) {
-                  const link = await pageHeader.getTopnavMenuLink(lvl2MenuItems.nth(k));
-                  if ((await MenuItemText(link)) === lvl2Category) {
-                    await verifyMenuItemHighlighting(link, 'left');
+          test('Only one filter can be expanded at a time', async ({}, testInfo) => {
+            test.setTimeout(testInfo.timeout + 30000);
+            const filterCategories = productCategoryPage.filterCategory;
+            const numFilterCategories = Object.keys(Filters[category]).length;
+            await expect.soft(filterCategories).toHaveCount(numFilterCategories);
+            for (let i = 0; i < numFilterCategories; i++) {
+              await filterCategories.nth(i).click();
+              for (let j = 0; j < numFilterCategories; j++) {
+                const categoryTitle = await productCategoryPage.getFilterCategoryElement(
+                  filterCategories.nth(j),
+                  'title',
+                );
+                const categoryContent = await productCategoryPage.getFilterCategoryElement(
+                  filterCategories.nth(j),
+                  'content',
+                );
+                await expect.soft(categoryTitle).toHaveAttribute('aria-selected', (i === j).toString());
+                await expect.soft(categoryTitle).toHaveAttribute('aria-expanded', (i === j).toString());
+                await expect.soft(categoryContent).toHaveAttribute('aria-hidden', (i !== j).toString());
+              }
+            }
+          });
+
+          test('Default product item details', async () => {
+            //There are a maximum of 12 products displayed by default
+            const productDetails = Products[category].slice(0, 12);
+            const productItems = productCategoryPage.productItem;
+            await expect.soft(productItems).toHaveCount(productDetails.length);
+            for (let i = 0; i < productDetails.length; i++) {
+              await expect
+                .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.Name))
+                .toHaveText(productDetails[i].title);
+              if (productDetails[i].rating) {
+                await expect
+                  .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.Rating))
+                  .toHaveText(productDetails[i].rating!);
+              }
+              if (productDetails[i].reviews) {
+                await expect
+                  .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.Reviews))
+                  .toHaveText(productDetails[i].reviews!);
+              }
+              await expect
+                .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.Price).first())
+                .toHaveText(productDetails[i].price);
+              if (productDetails[i].sizes) {
+                const sizes = productCategoryPage.getProductItemElement(i, ProductItemElements.Sizes);
+                await expect.soft(sizes).toHaveCount(productDetails[i].sizes!.length);
+                for (let j = 0; j < productDetails[i].sizes!.length; j++) {
+                  await expect.soft(sizes.nth(j)).toHaveText(productDetails[i].sizes![j]);
+                }
+              }
+              if (productDetails[i].colors) {
+                const colors = productCategoryPage.getProductItemElement(i, ProductItemElements.Colors);
+                await expect.soft(colors).toHaveCount(productDetails[i].colors!.length);
+                for (let j = 0; j < productDetails[i].colors!.length; j++) {
+                  await expect.soft(colors.nth(j)).toHaveCSS('background-color', productDetails[i].colors![j]);
+                }
+              }
+            }
+          });
+
+          test('Corresponding topnav item highlighted', async () => {
+            const pageHeader = productCategoryPage.pageHeader;
+            const lvl0MenuItems = await pageHeader.getTopnavMenuItem(pageHeader.topnav, 0);
+            const lvl0Keys = SubMenuKeys(HeaderLinks.Topnav);
+            await expect.soft(lvl0MenuItems).toHaveCount(lvl0Keys.length);
+            for (let i = 0; i < lvl0Keys.length; i++) {
+              const link = await pageHeader.getTopnavMenuLink(lvl0MenuItems.nth(i));
+              if ((await MenuItemText(link)) === lvl0Category) {
+                await verifyMenuItemHighlighting(link, 'bottom');
+
+                const lvl1MenuItems = await pageHeader.getTopnavMenuItem(lvl0MenuItems.nth(i), 1);
+                const lvl1Keys = SubMenuKeys(HeaderLinks.Topnav[`${lvl0Category}SubMenu`]);
+                await expect.soft(lvl1MenuItems).toHaveCount(lvl1Keys.length);
+
+                for (let j = 0; j < lvl1Keys.length; j++) {
+                  const link = await pageHeader.getTopnavMenuLink(lvl1MenuItems.nth(j));
+                  const lvl2MenuItems = await pageHeader.getTopnavMenuItem(lvl1MenuItems.nth(j), 2);
+                  if ((await MenuItemText(link)) === lvl1Category.replace('SubMenu', '')) {
+                    if (url.split('/').length === 3) {
+                      // Lvl1 category e.g. Women > Tops highlighted in topnav but no child menu items highlighted
+                      await verifyMenuItemHighlighting(link, 'left');
+
+                      if (
+                        Object.keys(HeaderLinks.Topnav[`${lvl0Category}SubMenu`]).includes(`${lvl1Category}SubMenu`)
+                      ) {
+                        const lvl2Keys = Object.keys(
+                          HeaderLinks.Topnav[`${lvl0Category}SubMenu`][`${lvl1Category}SubMenu`],
+                        );
+                        await expect.soft(lvl2MenuItems).toHaveCount(lvl2Keys.length);
+                        for (let k = 0; k < lvl2Keys.length; k++) {
+                          const link = await pageHeader.getTopnavMenuLink(lvl2MenuItems.nth(k));
+                          await verifyMenuItemHighlighting(link);
+                        }
+                      }
+                    }
+                    if (url.split('/').length === 4) {
+                      // Lvl2 category e.g. Women > Tops > Jackets highlighted in topnav but parent menu item not highlighted
+                      await verifyMenuItemHighlighting(link);
+
+                      const lvl2Keys = Object.keys(HeaderLinks.Topnav[`${lvl0Category}SubMenu`][lvl1Category]);
+                      await expect.soft(lvl2MenuItems).toHaveCount(lvl2Keys.length);
+                      for (let k = 0; k < lvl2Keys.length; k++) {
+                        const link = await pageHeader.getTopnavMenuLink(lvl2MenuItems.nth(k));
+                        if ((await MenuItemText(link)) === lvl2Category) {
+                          await verifyMenuItemHighlighting(link, 'left');
+                        } else {
+                          await verifyMenuItemHighlighting(link);
+                        }
+                      }
+                    }
                   } else {
                     await verifyMenuItemHighlighting(link);
                   }
                 }
+              } else {
+                await verifyMenuItemHighlighting(link);
               }
-            } else {
-              await verifyMenuItemHighlighting(link);
             }
-          }
-        } else {
-          await verifyMenuItemHighlighting(link);
-        }
-      }
-    });
-  });
+          });
+        });
 
-  test.describe('Link tests', () => {
-    test('Breadcrumb links', async ({ baseURL }) => {
-      const breadcrumbs = (await productCategoryPage.breadcrumbsContainer.innerText()).split('  ');
-      // The last breadcrumb doesn't have a link as it is the current page
-      for (let i = 0; i < breadcrumbs.length - 1; i++) {
-        await expect
-          .soft(productCategoryPage.breadcrumb.nth(i))
-          .toHaveAttribute('href', `${baseURL}${Links[category].Breadcrumbs[breadcrumbs[i]]}`);
-      }
-    });
+        test.describe('Link tests', () => {
+          test('Breadcrumb links', async ({ baseURL }) => {
+            const breadcrumbs = (await productCategoryPage.breadcrumbsContainer.innerText()).split('  ');
+            // The last breadcrumb doesn't have a link as it is the current page
+            for (let i = 0; i < breadcrumbs.length - 1; i++) {
+              await expect
+                .soft(productCategoryPage.breadcrumb.nth(i))
+                .toHaveAttribute('href', `${baseURL}${Links[category].Breadcrumbs[breadcrumbs[i]]}`);
+            }
+          });
 
-    test('Filter links', async ({ baseURL }) => {
-      const filterCategories = productCategoryPage.filterCategory;
-      const expectedFilters = Filters[category];
-      await expect.soft(filterCategories).toHaveCount(Object.keys(expectedFilters).length);
-      for (let i = 0; i < Object.keys(expectedFilters).length; i++) {
-        const categoryName = FilterCategoryName(await filterCategories.nth(i).innerText());
-        const filterItems = productCategoryPage.getFilterItems(filterCategories.nth(i), categoryName);
-        await expect.soft(filterItems).toHaveCount(expectedFilters[categoryName].length);
-        for (let j = 0; j < expectedFilters[categoryName].length; j++) {
-          const expectedUrl = `${baseURL}${expectedFilters[categoryName][j].link}`;
-          await expect.soft(filterItems.nth(j)).toHaveAttribute('href', expectedUrl);
-        }
-      }
-    });
+          test('Filter links', async ({ baseURL }) => {
+            const filterCategories = productCategoryPage.filterCategory;
+            const expectedFilters = Filters[category];
+            await expect.soft(filterCategories).toHaveCount(Object.keys(expectedFilters).length);
+            for (let i = 0; i < Object.keys(expectedFilters).length; i++) {
+              const categoryName = FilterCategoryName(await filterCategories.nth(i).innerText());
+              const filterItems = await productCategoryPage.getFilterItems(filterCategories.nth(i), categoryName);
+              await expect.soft(filterItems).toHaveCount(expectedFilters[categoryName].length);
+              for (let j = 0; j < expectedFilters[categoryName].length; j++) {
+                const expectedUrl = `${baseURL}${expectedFilters[categoryName][j].link}`;
+                await expect.soft(filterItems.nth(j)).toHaveAttribute('href', expectedUrl);
+              }
+            }
+          });
 
-    test('Default product links', async ({ baseURL }) => {
-      //There are a maximum of 12 products displayed by default
-      const productDetails = Products[category].slice(0, 12);
-      const products = productCategoryPage.productItem;
-      await expect.soft(products).toHaveCount(productDetails.length);
-      for (let i = 0; i < productDetails.length; i++) {
-        await expect
-          .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.PhotoLink))
-          .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
-        await expect
-          .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.NameLink))
-          .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
-        if (productDetails[i].reviews) {
-          await expect
-            .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.ReviewsLink))
-            .toHaveAttribute('href', `${baseURL}${productDetails[i].link}#reviews`);
-        } else {
-          await expect
-            .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.ReviewsLink))
-            .not.toBeVisible();
-        }
-      }
-    });
-  });
-});
+          test('Default product links', async ({ baseURL }) => {
+            //There are a maximum of 12 products displayed by default
+            const productDetails = Products[category].slice(0, 12);
+            const products = productCategoryPage.productItem;
+            await expect.soft(products).toHaveCount(productDetails.length);
+            for (let i = 0; i < productDetails.length; i++) {
+              await expect
+                .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.PhotoLink))
+                .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
+              await expect
+                .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.NameLink))
+                .toHaveAttribute('href', `${baseURL}${productDetails[i].link}`);
+              if (productDetails[i].reviews) {
+                await expect
+                  .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.ReviewsLink))
+                  .toHaveAttribute('href', `${baseURL}${productDetails[i].link}#reviews`);
+              } else {
+                await expect
+                  .soft(productCategoryPage.getProductItemElement(i, ProductItemElements.ReviewsLink))
+                  .not.toBeVisible();
+              }
+            }
+          });
+        });
+      });
+    }
+  }
+}

--- a/tests/specs/productCategoryPage.spec.ts
+++ b/tests/specs/productCategoryPage.spec.ts
@@ -89,6 +89,9 @@ for (const lvl0Category of lvl0Categories) {
             const expectedFilters = Filters[category];
             await expect.soft(filterCategories).toHaveCount(Object.keys(expectedFilters).length);
             for (let i = 0; i < Object.keys(expectedFilters).length; i++) {
+              await expect
+                .soft(await productCategoryPage.getFilterCategoryElement(filterCategories.nth(i), 'title'))
+                .toHaveAttribute('aria-expanded', 'false');
               const categoryName = FilterCategoryName(await filterCategories.nth(i).innerText());
               expect.soft(categoryName).toEqual(Object.keys(expectedFilters)[i]);
               const filterItems = await productCategoryPage.getFilterItems(filterCategories.nth(i), categoryName);
@@ -112,6 +115,9 @@ for (const lvl0Category of lvl0Categories) {
             const filterCategories = productCategoryPage.filterCategory;
             const numFilterCategories = Object.keys(Filters[category]).length;
             await expect.soft(filterCategories).toHaveCount(numFilterCategories);
+            await expect
+              .soft(await productCategoryPage.getFilterCategoryElement(filterCategories.first(), 'title'))
+              .toHaveAttribute('aria-expanded', 'false');
             for (let i = 0; i < numFilterCategories; i++) {
               await filterCategories.nth(i).click();
               for (let j = 0; j < numFilterCategories; j++) {
@@ -246,6 +252,9 @@ for (const lvl0Category of lvl0Categories) {
             const expectedFilters = Filters[category];
             await expect.soft(filterCategories).toHaveCount(Object.keys(expectedFilters).length);
             for (let i = 0; i < Object.keys(expectedFilters).length; i++) {
+              await expect
+                .soft(await productCategoryPage.getFilterCategoryElement(filterCategories.nth(i), 'title'))
+                .toHaveAttribute('aria-expanded', 'false');
               const categoryName = FilterCategoryName(await filterCategories.nth(i).innerText());
               const filterItems = await productCategoryPage.getFilterItems(filterCategories.nth(i), categoryName);
               await expect.soft(filterItems).toHaveCount(expectedFilters[categoryName].length);

--- a/tests/specs/productCategoryPage.spec.ts
+++ b/tests/specs/productCategoryPage.spec.ts
@@ -24,16 +24,16 @@ async function verifyMenuItemHighlighting(link: Locator, position?: 'left' | 'bo
 }
 
 dotenv.config();
-const lvl0Categories = process.env.TEST_MODE === 'limited' ? ['Women'] : Object.keys(ProductCategories);
+const lvl0Categories = process.env.TEST_MODE === 'full' ? Object.keys(ProductCategories) : ['Women'];
 for (const lvl0Category of lvl0Categories) {
-  const lvl1Categories = process.env.TEST_MODE === 'limited' ? ['Tops'] : Object.keys(ProductCategories[lvl0Category]);
+  const lvl1Categories = process.env.TEST_MODE === 'full' ? Object.keys(ProductCategories[lvl0Category]) : ['Tops'];
   for (const lvl1Category of lvl1Categories) {
     const lvl2Categories =
-      process.env.TEST_MODE === 'limited'
-        ? ['']
-        : lvl1Category.endsWith('SubMenu')
+      process.env.TEST_MODE === 'full'
+        ? lvl1Category.endsWith('SubMenu')
           ? Object.keys(ProductCategories[lvl0Category][lvl1Category])
-          : [''];
+          : ['']
+        : [''];
     for (const lvl2Category of lvl2Categories) {
       const category = lvl2Category ? `${lvl0Category}${lvl2Category}` : `${lvl0Category}${lvl1Category}`;
       const pageName = lvl2Category


### PR DESCRIPTION
To date the `collection` and `productCategory` specs have used a random page for each test. This has the advantage of increasing the test coverage without needing to duplicate tests. However, there are also the disadvantages of it being harder to debug any failures when the page used is random and it is difficult to ensure all necessary pages are adequately tested. 

This last point is the main reason for this PR. While developing visual tests for the collection pages (still WIP) I was able to create the Windows snapshots for all pages easily enough locally but I don't have a suitable environment for capturing the Linux snapshots locally so I run the CI pipeline to generate the required images. But given each test runs against a random page meant it would have taken several runs of the pipeline to generate all the snapshots.

For a while I had been toying with the idea of an environment variable to determine whether specs such as the `collection` and `productCategory` page specs use a random page or all relevant pages. This PR adds such an env var (`TEST_MODE`) and parameterises the tests within the aforementioned specs accordingly. 

When the env var is such that only a limited set of tests should be run the tests are run against a single page. The page used is no longer random and is the same page for all tests whereas previously different pages could be used for all tests. I can't decide whether this new approach is ideal but it is the best solution I have at this stage. I wanted to use a random page rather than fixing it to a specific page but I encountered a few issues with that solution. Playwright needs each test to be uniquely named, which I have achieved by adding the page name into the top-level describe block title. That's great, but if the page name is random (including if it is a random element from a predetermined array) then the test worker process needs to parse the spec file to generate the test names and while that is happening the first few tests in the spec can fail as they are invalidly named. I tried a number of alternatives including looping over the full array of all pages and skipping those that didn't match the randomly selected page but ultimately the same issues kept occurring so the obvious solution became to remove the randomness and use a known, fixed page in `limited` test mode. 

This solution addresses the issue of debugging failures being harder and given the option to test all pages in one run the test coverage is maintained (and potentially increased). Obviously there is the downside of the additional run time for the full test suite but hopefully that will be manageable. I will also look to optimise the CI pipeline based on trigger conditions in future PRs to help with the additional run time.