### PR TITLE
Make Sign In page tests more reliable

### DIFF
--- a/tests/specs/signInPage.spec.ts
+++ b/tests/specs/signInPage.spec.ts
@@ -27,6 +27,13 @@ test.describe('Sign in page tests', () => {
     });
 
     test.describe('Unsuccessful logins', () => {
+      test.beforeEach(async ({}) => {
+        // I HATE hardcoded waits and would rather wait on a page or element state but I _think_ the tests for unsuccessful logins
+        // sometimes fail when the page isn't in the right state at the point the test runs - but I can't find a way of verifying
+        // the correct page state before running these tests but a short wait seems to do the trick
+        await signInPage.page.waitForTimeout(250);
+      });
+
       test('Invalid credentials', async ({ page }) => {
         await signInPage.loginAs(unregisteredUser.email, unregisteredUser.password);
         await expect.soft(signInPage.errorMessage).toBeVisible();


### PR DESCRIPTION
Trying to reduce the flakiness of a test is always a tricky thing to do especially when the test is only somewhat flaky as is the case with the Sign In page tests for unsuccessful logins. Investigation has shown the wrong behaviour can be observed when the page in question isn't quite in the right state but quantifying that state has been difficult and I have been unable to find an element or API status to wait on (Playwright will already wait until the page load event has fired on navigating to the page) so I have been forced into using a short hardcoded wait ahead of each flaky test. This seems to have resolved the issue locally but I can't be 100% sure I have cured the problem so I am going to hope for a green pipeline, merge and then cross my fingers that the issue has indeed been resolved. If it transpires that the tests are still flaky then it's back to the drawing board and I'll either increase the timeout (reluctantly) or look into alternative solutions.