### PR TITLE
Improve CI pipelines

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,8 +17,7 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
         exclude:
-          - browser: ${{ github.event_name == 'pull_request' && 'firefox'}}
-          - browser: ${{ github.event_name == 'pull_request' && 'webkit'}}
+          - browser: ${{ github.event_name == 'pull_request' && 'firefox' && 'webkit'}}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,7 +5,7 @@ on:
     branches: main
 env:
   PASSWORD: ${{ secrets.PASSWORD }}
-  TEST_MODE: 'full'
+  TEST_MODE: ${{ github.event_name == 'pull_request' && 'limited' || 'full' }}
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,7 +17,8 @@ jobs:
       matrix:
         browser: [chromium, firefox, webkit]
         exclude:
-          - browser: ${{ github.event_name == 'pull_request' && 'firefox' && 'webkit'}}
+          - browser: ${{ github.event_name == 'pull_request' && 'firefox'}}
+          - browser: ${{ github.event_name == 'pull_request' && 'webkit'}}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         browser: [chromium, firefox, webkit]
     steps:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,6 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chromium, firefox, webkit]
+        exclude:
+          - browser: ${{ github.event_name == 'pull_request' && 'firefox'}}
+          - browser: ${{ github.event_name == 'pull_request' && 'webkit'}}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   pull_request:
     branches: main
+  schedule:
+    # Runs at 8am UTC Mon-Fri
+    - cron: '0 8 * * 1-5'
 env:
   PASSWORD: ${{ secrets.PASSWORD }}
   TEST_MODE: ${{ github.event_name == 'pull_request' && 'limited' || 'full' }}

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -1,0 +1,30 @@
+name: Visual Tests
+on:
+  workflow_dispatch:
+env:
+  PASSWORD: ${{ secrets.PASSWORD }}
+  TEST_MODE: 'full'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps ${{matrix.browser}}
+      - name: Run Playwright visual tests (only)
+        run: npx playwright test --project=${{matrix.browser}} --grep=visual
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-${{matrix.browser}}
+          path: tests/playwright-report/
+          retention-days: 30

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -1,6 +1,8 @@
 name: Visual Tests
 on:
   workflow_dispatch:
+  pull_request:
+    branches: main
 env:
   PASSWORD: ${{ secrets.PASSWORD }}
   TEST_MODE: 'full'

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -1,8 +1,6 @@
 name: Visual Tests
 on:
   workflow_dispatch:
-  pull_request:
-    branches: main
 env:
   PASSWORD: ${{ secrets.PASSWORD }}
   TEST_MODE: 'full'

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "pw:chromium": "npx playwright test --project=chromium",
     "pw:firefox": "npx playwright test --project=firefox",
     "pw:webkit": "npx playwright test --project=webkit",
-    "pw:all": "npx playwright test"
+    "pw:all": "npx playwright test",
+    "pw:visual": "npm run pw:all -- --grep=visual"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
I've been wanting to make several changes to the CI pipelines for a little while now and as they were all relatively small I decided to combine several together into a single PR. The main changes are:

- Only run a limited set of tests and only against Chromium when the workflow is triggered by a PR targeting `main` (such as this one)
  - The full test suite takes quite a while to run even though all browsers are now tested in parallel whereas when creating a PR we generally want fast feedback that the changes haven't broken anything, in which case a limited run (one product category page, one collection page etc) on a single browser should give us a reasonable degree of confidence. The full test suite can still be run manually if desired, which I did for this PR - see the results [here](https://github.com/mathare/playwright-typescript/actions/runs/9467733404)
- A cron trigger to run the full test suite at 8am UTC each weekday
  - Now we're not running the full test suite on every PR we still want to run it periodically to ensure any recent changes haven't broken anything and to catch any issues we may have introduced. By adding a cron job we can run the full test suite regularly (every morning in this instance) which should help catch any issues whether they be as a result of recent changes I have made or data changes on the 3rd party website under test
  - NB This change is currently untested but I am confident the syntax is correct. The real test will come in the morning when the first run should be triggered
- A new visual tests workflow making it easier to run just the visual tests, across all browsers, to make it easier to capture snapshots on Linux as required
  - I have also added a new script to run the visual tests but that is not used in the CI workflow due to the parallel nature of the different browser jobs

