### PR TITLE
Rework product test data

### DIFF
--- a/tests/data/collections/ecoCollection.ts
+++ b/tests/data/collections/ecoCollection.ts
@@ -1,9 +1,9 @@
 import { Product } from '../products';
 import { CollectionExpectedText } from './shared';
-import * as MenHoodies from '../productCategories/menHoodies';
-import * as WomenTees from '../productCategories/womenTees';
-import * as WomenShorts from '../productCategories/womenShorts';
-import * as WomenJackets from '../productCategories/womenJackets';
+import { ProductDetails as MenHoodies } from '../productCategories/menHoodies';
+import { ProductDetails as WomenTees } from '../productCategories/womenTees';
+import { ProductDetails as WomenShorts } from '../productCategories/womenShorts';
+import { ProductDetails as WomenJackets } from '../productCategories/womenJackets';
 
 export const Url = '/collections/eco-new.html';
 
@@ -22,9 +22,9 @@ export const Links = {
 };
 
 export const Products: Product[] = [
-  MenHoodies.Products[10],
-  WomenTees.Products[9],
-  WomenShorts.Products[11],
-  WomenJackets.Products[11],
-  WomenTees.Products[8],
+  MenHoodies.Bruno,
+  WomenTees.Layla,
+  WomenShorts.Fiona,
+  WomenJackets.Stellar,
+  WomenTees.Elisa,
 ];

--- a/tests/data/collections/gear.ts
+++ b/tests/data/collections/gear.ts
@@ -1,7 +1,7 @@
 import { Product } from '../products';
 import { CollectionExpectedText, Filter, ShoppingOptions } from './shared';
-import * as Bags from '../productCategories/gearBags';
-import * as Equipment from '../productCategories/gearFitnessEquipment';
+import { ProductDetails as Bags } from '../productCategories/gearBags';
+import { ProductDetails as Equipment } from '../productCategories/gearFitnessEquipment';
 import { Links as HeaderLinks } from '../pageHeader';
 
 export const ExpectedText: CollectionExpectedText = {
@@ -68,4 +68,4 @@ export const Filters: Filter[] = [
   },
 ];
 
-export const Products: Product[] = [Bags.Products[8], Bags.Products[0], Equipment.Products[10], Equipment.Products[0]];
+export const Products: Product[] = [Bags.Fusion, Bags.PushIt, Equipment.WaterBottle, Equipment.SpriteKit];

--- a/tests/data/collections/men.ts
+++ b/tests/data/collections/men.ts
@@ -1,9 +1,9 @@
 import { Product } from '../products';
 import { CollectionExpectedText, Filter, ShoppingOptions } from './shared';
-import * as Hoodies from '../productCategories/menHoodies';
-import * as Pants from '../productCategories/menPants';
-import * as Shorts from '../productCategories/menShorts';
-import * as Tanks from '../productCategories/menTanks';
+import { ProductDetails as Hoodies } from '../productCategories/menHoodies';
+import { ProductDetails as Pants } from '../productCategories/menPants';
+import { ProductDetails as Shorts } from '../productCategories/menShorts';
+import { ProductDetails as Tanks } from '../productCategories/menTanks';
 import { Links as HeaderLinks } from '../pageHeader';
 
 export const ExpectedText: CollectionExpectedText = {
@@ -73,4 +73,4 @@ export const Filters: Filter[] = [
   },
 ];
 
-export const Products: Product[] = [Tanks.Products[5], Hoodies.Products[6], Shorts.Products[9], Pants.Products[9]];
+export const Products: Product[] = [Tanks.Argus, Hoodies.Hero, Shorts.Meteor, Pants.Geo];

--- a/tests/data/collections/performanceFabrics.ts
+++ b/tests/data/collections/performanceFabrics.ts
@@ -1,10 +1,10 @@
 import { Product } from '../products';
 import { CollectionExpectedText } from './shared';
-import * as MenJackets from '../productCategories/menJackets';
-import * as MenTanks from '../productCategories/menTanks';
-import * as WomenJackets from '../productCategories/womenJackets';
-import * as WomenTees from '../productCategories/womenTees';
-import * as WomenShorts from '../productCategories/womenShorts';
+import { ProductDetails as MenJackets } from '../productCategories/menJackets';
+import { ProductDetails as MenTanks } from '../productCategories/menTanks';
+import { ProductDetails as WomenJackets } from '../productCategories/womenJackets';
+import { ProductDetails as WomenTees } from '../productCategories/womenTees';
+import { ProductDetails as WomenShorts } from '../productCategories/womenShorts';
 
 export const Url = '/collections/performance-new.html';
 
@@ -23,9 +23,9 @@ export const Links = {
 };
 
 export const Products: Product[] = [
-  MenJackets.Products[9],
-  MenTanks.Products[8],
-  WomenJackets.Products[8],
-  WomenTees.Products[7],
-  WomenShorts.Products[9],
+  MenJackets.Hyperion,
+  MenTanks.Helios,
+  WomenJackets.Ingrid,
+  WomenTees.Juliana,
+  WomenShorts.Gwen,
 ];

--- a/tests/data/collections/women.ts
+++ b/tests/data/collections/women.ts
@@ -1,9 +1,9 @@
 import { Product } from '../products';
 import { CollectionExpectedText, Filter, ShoppingOptions } from './shared';
-import * as Hoodies from '../productCategories/womenHoodies';
-import * as Pants from '../productCategories/womenPants';
-import * as Tanks from '../productCategories/womenTanks';
-import * as Tees from '../productCategories/womenTees';
+import { ProductDetails as Hoodies } from '../productCategories/womenHoodies';
+import { ProductDetails as Pants } from '../productCategories/womenPants';
+import { ProductDetails as Tanks } from '../productCategories/womenTanks';
+import { ProductDetails as Tees } from '../productCategories/womenTees';
 import { Links as HeaderLinks } from '../pageHeader';
 
 export const ExpectedText: CollectionExpectedText = {
@@ -75,4 +75,4 @@ export const Filters: Filter[] = [
   },
 ];
 
-export const Products: Product[] = [Tees.Products[2], Tanks.Products[0], Hoodies.Products[7], Pants.Products[1]];
+export const Products: Product[] = [Tees.Radiant, Tanks.BreatheEasy, Hoodies.Selene, Pants.Deirdre];

--- a/tests/data/homePage.ts
+++ b/tests/data/homePage.ts
@@ -1,8 +1,8 @@
-import * as WomenTanks from './productCategories/womenTanks';
-import * as WomenTees from './productCategories/womenTees';
-import * as MenHoodies from './productCategories/menHoodies';
-import * as MenTanks from './productCategories/menTanks';
-import * as GearBags from './productCategories/gearBags';
+import { ProductDetails as WomenTanks } from './productCategories/womenTanks';
+import { ProductDetails as WomenTees } from './productCategories/womenTees';
+import { ProductDetails as MenHoodies } from './productCategories/menHoodies';
+import { ProductDetails as MenTanks } from './productCategories/menTanks';
+import { ProductDetails as GearBags } from './productCategories/gearBags';
 import * as Yoga from './productCategories/yoga';
 import * as ErinRecommends from './productCategories/erinRecommends';
 import * as AllPants from './productCategories/allPants';
@@ -20,15 +20,13 @@ export const ExpectedText = {
   ContentHeading: 'Hot Sellers Here is what`s trending on Luma right now',
 };
 
-// I'm not convinced this is the best way of doing this as I would like to avoid using hardcoded array indices where possible
-// However, this works for now and I will look at a better way of doing it down the line
 export const Products = [
-  WomenTees.Products[2],
-  WomenTanks.Products[0],
-  MenTanks.Products[5],
-  MenHoodies.Products[6],
-  GearBags.Products[8],
-  GearBags.Products[0],
+  WomenTees.Radiant,
+  WomenTanks.BreatheEasy,
+  MenTanks.Argus,
+  MenHoodies.Hero,
+  GearBags.Fusion,
+  GearBags.PushIt,
 ];
 
 export const PromoBlockLinks = [

--- a/tests/data/productCategories/erinRecommends.ts
+++ b/tests/data/productCategories/erinRecommends.ts
@@ -1,12 +1,12 @@
 import { FilterCategory, ProductCategoryExpectedText } from './shared';
-import { Products as MenPants } from './menPants';
-import { Products as MenShorts } from './menShorts';
-import { Products as WomenHoodies } from './womenHoodies';
-import { Products as WomenJackets } from './womenJackets';
-import { Products as WomenPants } from './womenPants';
-import { Products as WomenShorts } from './womenShorts';
-import { Products as WomenTanks } from './womenTanks';
-import { Products as WomenTees } from './womenTees';
+import { ProductDetails as MenPants } from './menPants';
+import { ProductDetails as MenShorts } from './menShorts';
+import { ProductDetails as WomenHoodies } from './womenHoodies';
+import { ProductDetails as WomenJackets } from './womenJackets';
+import { ProductDetails as WomenPants } from './womenPants';
+import { ProductDetails as WomenShorts } from './womenShorts';
+import { ProductDetails as WomenTanks } from './womenTanks';
+import { ProductDetails as WomenTees } from './womenTees';
 import { Product } from '../products';
 
 export const ExpectedText: ProductCategoryExpectedText = {
@@ -179,25 +179,25 @@ export const Filters: FilterCategory[] = [
 ];
 
 export const Products: Product[] = [
-  WomenShorts[0],
-  WomenShorts[1],
-  WomenPants[0],
-  WomenPants[7],
-  WomenPants[8],
-  WomenTanks[0],
-  WomenTanks[4],
-  WomenTanks[6],
-  WomenTees[3],
-  WomenTees[7],
-  WomenJackets[4],
-  WomenJackets[5],
-  WomenJackets[11],
-  WomenHoodies[1],
-  WomenHoodies[5],
-  WomenHoodies[11],
-  MenShorts[5],
-  MenShorts[11],
-  MenPants[1],
-  MenPants[2],
-  MenPants[3],
+  WomenShorts.Erika,
+  WomenShorts.Ina,
+  WomenPants.Portia,
+  WomenPants.Diana,
+  WomenPants.Sahara,
+  WomenTanks.BreatheEasy,
+  WomenTanks.Leah,
+  WomenTanks.Nora,
+  WomenTees.Diva,
+  WomenTees.Juliana,
+  WomenJackets.Jade,
+  WomenJackets.Adrienne,
+  WomenJackets.Stellar,
+  WomenHoodies.Eos,
+  WomenHoodies.Phoebe,
+  WomenHoodies.Mona,
+  MenShorts.Rapha,
+  MenShorts.Cobalt,
+  MenPants.Aether,
+  MenPants.Orestes,
+  MenPants.Livingston,
 ];

--- a/tests/data/productCategories/gearBags.ts
+++ b/tests/data/productCategories/gearBags.ts
@@ -111,8 +111,8 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  PushIt: {
     name: 'Push It Messenger Bag',
     rating: '67%',
     reviews: '3 Reviews',
@@ -120,56 +120,56 @@ export const Products: Product[] = [
     link: '/push-it-messenger-bag.html',
     images: { default: '/w/b/wb04-blue-0.jpg' },
   },
-  {
+  Overnight: {
     name: 'Overnight Duffle',
     rating: '60%',
     reviews: '3 Reviews',
     price: '$45.00',
     link: '/overnight-duffle.html',
   },
-  {
+  Driven: {
     name: 'Driven Backpack',
     rating: '90%',
     reviews: '2 Reviews',
     price: '$36.00',
     link: '/driven-backpack.html',
   },
-  {
+  Endeavor: {
     name: 'Endeavor Daytrip Backpack',
     rating: '73%',
     reviews: '3 Reviews',
     price: '$33.00',
     link: '/endeavor-daytrip-backpack.html',
   },
-  {
+  Savvy: {
     name: 'Savvy Shoulder Tote',
     rating: '80%',
     reviews: '2 Reviews',
     price: 'Special Price\n$24.00 Regular Price $32.00',
     link: '/savvy-shoulder-tote.html',
   },
-  {
+  Compete: {
     name: 'Compete Track Tote',
     rating: '70%',
     reviews: '2 Reviews',
     price: '$32.00',
     link: '/compete-track-tote.html',
   },
-  {
+  Voyage: {
     name: 'Voyage Yoga Bag',
     rating: '67%',
     reviews: '3 Reviews',
     price: '$32.00',
     link: '/voyage-yoga-bag.html',
   },
-  {
+  Impulse: {
     name: 'Impulse Duffle',
     rating: '80%',
     reviews: '3 Reviews',
     price: '$74.00',
     link: '/impulse-duffle.html',
   },
-  {
+  Fusion: {
     name: 'Fusion Backpack',
     rating: '67%',
     reviews: '3 Reviews',
@@ -177,39 +177,56 @@ export const Products: Product[] = [
     link: '/fusion-backpack.html',
     images: { default: '/m/b/mb02-gray-0.jpg' },
   },
-  {
+  Rival: {
     name: 'Rival Field Messenger',
     rating: '70%',
     reviews: '2 Reviews',
     price: '$45.00',
     link: '/rival-field-messenger.html',
   },
-  {
+  Wayfarer: {
     name: 'Wayfarer Messenger Bag',
     rating: '67%',
     reviews: '3 Reviews',
     price: '$45.00',
     link: '/wayfarer-messenger-bag.html',
   },
-  {
+  Crown: {
     name: 'Crown Summit Backpack',
     rating: '67%',
     reviews: '3 Reviews',
     price: '$38.00',
     link: '/crown-summit-backpack.html',
   },
-  {
+  Strive: {
     name: 'Strive Shoulder Pack',
     rating: '90%',
     reviews: '2 Reviews',
     price: '$32.00',
     link: '/strive-shoulder-pack.html',
   },
-  {
+  Joust: {
     name: 'Joust Duffle Bag',
     rating: '50%',
     reviews: '2 Reviews',
     price: '$34.00',
     link: '/joust-duffle-bag.html',
   },
+};
+
+export const Products = [
+  ProductDetails.PushIt,
+  ProductDetails.Overnight,
+  ProductDetails.Driven,
+  ProductDetails.Endeavor,
+  ProductDetails.Savvy,
+  ProductDetails.Compete,
+  ProductDetails.Voyage,
+  ProductDetails.Impulse,
+  ProductDetails.Fusion,
+  ProductDetails.Rival,
+  ProductDetails.Wayfarer,
+  ProductDetails.Crown,
+  ProductDetails.Strive,
+  ProductDetails.Joust,
 ];

--- a/tests/data/productCategories/gearFitnessEquipment.ts
+++ b/tests/data/productCategories/gearFitnessEquipment.ts
@@ -92,74 +92,88 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  SpriteKit: {
     name: 'Sprite Yoga Companion Kit',
     price: 'From $61.00\n\nTo $77.00',
     link: '/sprite-yoga-companion-kit.html',
   },
-  {
+  SpriteStraps: {
     name: 'Set of Sprite Yoga Straps',
     price: 'Starting at\n$14.00',
     link: '/set-of-sprite-yoga-straps.html',
   },
-  {
+  HarmonyKit: {
     name: 'Harmony Lumaflex™ Strength Band Kit',
     rating: '60%',
     reviews: '3 Reviews',
     price: '$22.00',
     link: '/harmony-lumaflex-trade-strength-band-kit.html',
   },
-  {
+  SpriteRoller: {
     name: 'Sprite Foam Roller',
     price: '$19.00',
     link: '/sprite-foam-roller.html',
   },
-  {
+  SpriteBrick: {
     name: 'Sprite Foam Yoga Brick',
     price: '$5.00',
     link: '/sprite-foam-yoga-brick.html',
   },
-  {
+  QuestBand: {
     name: 'Quest Lumaflex™ Band',
     rating: '67%',
     reviews: '3 Reviews',
     price: '$19.00',
     link: '/quest-lumaflex-trade-band.html',
   },
-  {
+  PushupGrips: {
     name: "Go-Get'r Pushup Grips",
     rating: '87%',
     reviews: '3 Reviews',
     price: '$19.00',
     link: '/go-get-r-pushup-grips.html',
   },
-  {
+  PursuitBand: {
     name: 'Pursuit Lumaflex™ Tone Band',
     rating: '60%',
     reviews: '2 Reviews',
     price: '$16.00',
     link: '/pursuit-lumaflex-trade-tone-band.html',
   },
-  {
+  JumpRope: {
     name: 'Zing Jump Rope',
     rating: '93%',
     reviews: '3 Reviews',
     price: '$12.00',
     link: '/zing-jump-rope.html',
   },
-  {
+  CardioBall: {
     name: 'Dual Handle Cardio Ball',
     rating: '100%',
     reviews: '2 Reviews',
     price: '$12.00',
     link: '/dual-handle-cardio-ball.html',
   },
-  {
+  WaterBottle: {
     name: 'Affirm Water Bottle',
     rating: '60%',
     reviews: '1 Review',
     price: '$7.00',
     link: '/affirm-water-bottle.html',
   },
+};
+
+export const Products = [
+  ProductDetails.SpriteKit,
+  ProductDetails.SpriteStraps,
+  ProductDetails.HarmonyKit,
+  ProductDetails.SpriteRoller,
+  ProductDetails.SpriteBrick,
+  ProductDetails.QuestBand,
+  ProductDetails.PushupGrips,
+  ProductDetails.PursuitBand,
+  ProductDetails.JumpRope,
+  ProductDetails.CardioBall,
+  ProductDetails.WaterBottle,
 ];

--- a/tests/data/productCategories/gearWatches.ts
+++ b/tests/data/productCategories/gearWatches.ts
@@ -72,68 +72,80 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Didi: {
     name: 'Didi Sport Watch',
     rating: '70%',
     reviews: '2 Reviews',
     price: '$92.00',
     link: '/didi-sport-watch.html',
   },
-  {
+  Clamber: {
     name: 'Clamber Watch',
     rating: '53%',
     reviews: '3 Reviews',
     price: '$54.00',
     link: '/clamber-watch.html',
   },
-  {
+  Bolo: {
     name: 'Bolo Sport Watch',
     rating: '67%',
     reviews: '3 Reviews',
     price: '$49.00',
     link: '/bolo-sport-watch.html',
   },
-  {
+  Luma: {
     name: 'Luma Analog Watch',
     rating: '80%',
     reviews: '2 Reviews',
     price: '$43.00',
     link: '/luma-analog-watch.html',
   },
-  {
+  Dash: {
     name: 'Dash Digital Watch',
     rating: '73%',
     reviews: '3 Reviews',
     price: '$92.00',
     link: '/dash-digital-watch.html',
   },
-  {
+  Cruise: {
     name: 'Cruise Dual Analog Watch',
     rating: '65%',
     reviews: '4 Reviews',
     price: '$55.00',
     link: '/cruise-dual-analog-watch.html',
   },
-  {
+  Summit: {
     name: 'Summit Watch',
     rating: '47%',
     reviews: '3 Reviews',
     price: '$54.00',
     link: '/summit-watch.html',
   },
-  {
+  Endurance: {
     name: 'Endurance Watch',
     rating: '87%',
     reviews: '3 Reviews',
     price: '$49.00',
     link: '/endurance-watch.html',
   },
-  {
+  Aim: {
     name: 'Aim Analog Watch',
     rating: '80%',
     reviews: '2 Reviews',
     price: '$45.00',
     link: '/aim-analog-watch.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Didi,
+  ProductDetails.Clamber,
+  ProductDetails.Bolo,
+  ProductDetails.Luma,
+  ProductDetails.Dash,
+  ProductDetails.Cruise,
+  ProductDetails.Summit,
+  ProductDetails.Endurance,
+  ProductDetails.Aim,
 ];

--- a/tests/data/productCategories/menHoodies.ts
+++ b/tests/data/productCategories/menHoodies.ts
@@ -205,50 +205,50 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Marco: {
     name: 'Marco Lightweight Active Hoodie',
     price: 'As low as $74.00',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Green, Colors.Lavender],
     link: '/marco-lightweight-active-hoodie.html',
   },
-  {
+  Ajax: {
     name: 'Ajax Full-Zip Sweatshirt',
     price: 'As low as $69.00',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Green, Colors.Red],
     link: '/ajax-full-zip-sweatshirt.html',
   },
-  {
+  Grayson: {
     name: 'Grayson Crewneck Sweatshirt',
     price: 'As low as $64.00',
     sizes: Sizes,
     colors: [Colors.Orange, Colors.Red, Colors.White],
     link: '/grayson-crewneck-sweatshirt.html',
   },
-  {
+  Mach: {
     name: 'Mach Street Sweatshirt',
     price: 'As low as $62.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/mach-street-sweatshirt.html',
   },
-  {
+  Abominable: {
     name: 'Abominable Hoodie',
     price: 'As low as $69.00',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Green, Colors.Red],
     link: '/abominable-hoodie.html',
   },
-  {
+  Oslo: {
     name: 'Oslo Trek Hoodie',
     price: 'As low as $42.00',
     sizes: Sizes,
     colors: [Colors.Brown, Colors.Purple, Colors.Red],
     link: '/oslo-trek-hoodie.html',
   },
-  {
+  Hero: {
     name: 'Hero Hoodie',
     price: 'As low as $54.00',
     sizes: Sizes,
@@ -267,46 +267,62 @@ export const Products: Product[] = [
       ],
     },
   },
-  {
+  Stark: {
     name: 'Stark Fundamental Hoodie',
     price: 'As low as $42.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Purple],
     link: '/stark-fundamental-hoodie.html',
   },
-  {
+  Hollister: {
     name: 'Hollister Backyard Sweatshirt',
     price: 'As low as $52.00',
     sizes: Sizes,
     colors: [Colors.Green, Colors.Red, Colors.White],
     link: '/hollister-backyard-sweatshirt.html',
   },
-  {
+  Frankie: {
     name: 'Frankie Sweatshirt',
     price: 'As low as $60.00',
     sizes: Sizes,
     colors: [Colors.Green, Colors.White, Colors.Yellow],
     link: '/frankie-sweatshirt.html',
   },
-  {
+  Bruno: {
     name: 'Bruno Compete Hoodie',
     price: 'As low as $63.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Green],
     link: '/bruno-compete-hoodie.html',
   },
-  {
+  Teton: {
     name: 'Teton Pullover Hoodie',
     price: 'As low as $70.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Purple, Colors.Red],
     link: '/teton-pullover-hoodie.html',
   },
-  {
+  Chaz: {
     name: 'Chaz Kangeroo Hoodie',
     price: 'As low as $52.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Grey, Colors.Orange],
     link: '/chaz-kangeroo-hoodie.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Marco,
+  ProductDetails.Ajax,
+  ProductDetails.Grayson,
+  ProductDetails.Mach,
+  ProductDetails.Abominable,
+  ProductDetails.Oslo,
+  ProductDetails.Hero,
+  ProductDetails.Stark,
+  ProductDetails.Hollister,
+  ProductDetails.Frankie,
+  ProductDetails.Bruno,
+  ProductDetails.Teton,
+  ProductDetails.Chaz,
 ];

--- a/tests/data/productCategories/menJackets.ts
+++ b/tests/data/productCategories/menJackets.ts
@@ -151,15 +151,15 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Proteus: {
     name: 'Proteus Fitness Jackshirt',
     price: 'As low as $45.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Orange],
     link: '/proteus-fitness-jackshirt.html',
   },
-  {
+  Montana: {
     name: 'Montana Wind Jacket',
     rating: '53%',
     reviews: '3 Reviews',
@@ -168,7 +168,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Green, Colors.Red],
     link: '/montana-wind-jacket.html',
   },
-  {
+  Jupiter: {
     name: 'Jupiter All-Weather Trainer',
     rating: '80%',
     reviews: '3 Reviews',
@@ -177,14 +177,14 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Green, Colors.Purple],
     link: '/jupiter-all-weather-trainer.html',
   },
-  {
+  Typhon: {
     name: 'Typhon Performance Fleece-lined Jacket',
     price: 'As low as $60.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Green, Colors.Red],
     link: '/typhon-performance-fleece-lined-jacket.html',
   },
-  {
+  Mars: {
     name: 'Mars HeatTech™ Pullover',
     rating: '70%',
     reviews: '2 Reviews',
@@ -193,7 +193,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Orange, Colors.Red],
     link: '/mars-heattech-trade-pullover.html',
   },
-  {
+  Taurus: {
     name: 'Taurus Elements Shell',
     rating: '70%',
     reviews: '2 Reviews',
@@ -202,7 +202,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.White, Colors.Yellow],
     link: '/taurus-elements-shell.html',
   },
-  {
+  Lando: {
     name: 'Lando Gym Jacket',
     rating: '67%',
     reviews: '3 Reviews',
@@ -211,7 +211,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Grey, Colors.Green],
     link: '/lando-gym-jacket.html',
   },
-  {
+  Orion: {
     name: 'Orion Two-Tone Fitted Jacket',
     rating: '50%',
     reviews: '2 Reviews',
@@ -220,7 +220,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Red, Colors.Yellow],
     link: '/orion-two-tone-fitted-jacket.html',
   },
-  {
+  Kenobi: {
     name: 'Kenobi Trail Jacket',
     rating: '93%',
     reviews: '3 Reviews',
@@ -229,7 +229,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Purple],
     link: '/kenobi-trail-jacket.html',
   },
-  {
+  Hyperion: {
     name: 'Hyperion Elements Jacket',
     rating: '90%',
     reviews: '2 Reviews',
@@ -238,7 +238,7 @@ export const Products: Product[] = [
     colors: [Colors.Green, Colors.Orange, Colors.Red],
     link: '/hyperion-elements-jacket.html',
   },
-  {
+  Beaumont: {
     name: 'Beaumont Summit Kit',
     rating: '90%',
     reviews: '2 Reviews',
@@ -247,4 +247,18 @@ export const Products: Product[] = [
     colors: [Colors.Orange, Colors.Red, Colors.Yellow],
     link: '/beaumont-summit-kit.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Proteus,
+  ProductDetails.Montana,
+  ProductDetails.Jupiter,
+  ProductDetails.Typhon,
+  ProductDetails.Mars,
+  ProductDetails.Taurus,
+  ProductDetails.Lando,
+  ProductDetails.Orion,
+  ProductDetails.Kenobi,
+  ProductDetails.Hyperion,
+  ProductDetails.Beaumont,
 ];

--- a/tests/data/productCategories/menPants.ts
+++ b/tests/data/productCategories/menPants.ts
@@ -147,57 +147,57 @@ export const Filters: FilterCategory[] = [
 
 const Sizes = ['32', '33', '34', '36'];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Cronus: {
     name: 'Cronus Yoga Pant',
     price: 'As low as $38.40',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/cronus-yoga-pant.html',
   },
-  {
+  Aether: {
     name: 'Aether Gym Pant',
     price: 'As low as $59.20',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Brown, Colors.Green],
     link: '/aether-gym-pant.html',
   },
-  {
+  Orestes: {
     name: 'Orestes Yoga Pant',
     price: 'As low as $52.80',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Green],
     link: '/orestes-yoga-pant.html',
   },
-  {
+  Livingston: {
     name: 'Livingston All-Purpose Tight',
     price: 'As low as $60.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/livingston-all-purpose-tight.html',
   },
-  {
+  Zeppelin: {
     name: 'Zeppelin Yoga Pant',
     price: 'As low as $65.60',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Green, Colors.Red],
     link: '/zeppelin-yoga-pant.html',
   },
-  {
+  Thorpe: {
     name: 'Thorpe Track Pant',
     price: 'As low as $54.40',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Purple],
     link: '/thorpe-track-pant.html',
   },
-  {
+  Mithra: {
     name: 'Mithra Warmup Pant',
     price: 'As low as $22.40',
     sizes: Sizes,
     colors: [Colors.Grey, Colors.Green, Colors.Orange],
     link: '/mithra-warmup-pant.html',
   },
-  {
+  Kratos: {
     name: 'Kratos Gym Pant',
     rating: '73%',
     reviews: '3 Reviews',
@@ -206,7 +206,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Green],
     link: '/kratos-gym-pant.html',
   },
-  {
+  Supernova: {
     name: 'Supernova Sport Pant',
     rating: '87%',
     reviews: '3 Reviews',
@@ -215,7 +215,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Grey, Colors.Green],
     link: '/supernova-sport-pant.html',
   },
-  {
+  Geo: {
     name: 'Geo Insulated Jogging Pant',
     rating: '70%',
     reviews: '2 Reviews',
@@ -224,7 +224,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Green, Colors.Red],
     link: '/geo-insulated-jogging-pant.html',
   },
-  {
+  Viktor: {
     name: 'Viktor LumaTech™ Pant',
     rating: '47%',
     reviews: '3 Reviews',
@@ -233,7 +233,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Grey, Colors.Red],
     link: '/viktor-lumatech-trade-pant.html',
   },
-  {
+  Caesar: {
     name: 'Caesar Warm-Up Pant',
     rating: '47%',
     reviews: '3 Reviews',
@@ -242,4 +242,19 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Grey, Colors.Purple],
     link: '/caesar-warm-up-pant.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Cronus,
+  ProductDetails.Aether,
+  ProductDetails.Orestes,
+  ProductDetails.Livingston,
+  ProductDetails.Zeppelin,
+  ProductDetails.Thorpe,
+  ProductDetails.Mithra,
+  ProductDetails.Kratos,
+  ProductDetails.Supernova,
+  ProductDetails.Geo,
+  ProductDetails.Viktor,
+  ProductDetails.Caesar,
 ];

--- a/tests/data/productCategories/menSale.ts
+++ b/tests/data/productCategories/menSale.ts
@@ -1,5 +1,5 @@
 import { FilterCategory, ProductCategoryExpectedText } from './shared';
-import { Products as MenShorts } from './menShorts';
+import { ProductDetails as MenShorts } from './menShorts';
 import { Product } from '../products';
 
 export const ExpectedText: ProductCategoryExpectedText = {
@@ -109,4 +109,4 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [MenShorts[0], MenShorts[4], MenShorts[5]];
+export const Products: Product[] = [MenShorts.Pierce, MenShorts.Orestes, MenShorts.Rapha];

--- a/tests/data/productCategories/menShorts.ts
+++ b/tests/data/productCategories/menShorts.ts
@@ -152,29 +152,29 @@ export const Filters: FilterCategory[] = [
 
 const Sizes = ['32', '33', '34', '36'];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Pierce: {
     name: 'Pierce Gym Short',
     price: 'As low as $27.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Grey, Colors.Red],
     link: '/pierce-gym-short.html',
   },
-  {
+  Arcadio: {
     name: 'Arcadio Gym Short',
     price: 'As low as $20.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/arcadio-gym-short.html',
   },
-  {
+  Sol: {
     name: 'Sol Active Short',
     price: 'As low as $32.00',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Green, Colors.Purple],
     link: '/sol-active-short.html',
   },
-  {
+  Troy: {
     name: 'Troy Yoga Short',
     rating: '67%',
     reviews: '3 Reviews',
@@ -183,7 +183,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Green],
     link: '/troy-yoga-short.html',
   },
-  {
+  Orestes: {
     name: 'Orestes Fitness Short',
     rating: '60%',
     reviews: '2 Reviews',
@@ -192,7 +192,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Green],
     link: '/orestes-fitness-short.html',
   },
-  {
+  Rapha: {
     name: 'Rapha Sports Short',
     rating: '87%',
     reviews: '3 Reviews',
@@ -201,7 +201,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Purple],
     link: '/rapha-sports-short.html',
   },
-  {
+  Lono: {
     name: 'Lono Yoga Short',
     rating: '70%',
     reviews: '2 Reviews',
@@ -210,7 +210,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Grey, Colors.Red],
     link: '/lono-yoga-short.html',
   },
-  {
+  Hawkeye: {
     name: 'Hawkeye Yoga Short',
     rating: '73%',
     reviews: '3 Reviews',
@@ -219,7 +219,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Grey],
     link: '/hawkeye-yoga-short.html',
   },
-  {
+  Torque: {
     name: 'Torque Power Short',
     rating: '60%',
     reviews: '3 Reviews',
@@ -228,7 +228,7 @@ export const Products: Product[] = [
     colors: [Colors.Grey, Colors.Purple, Colors.Yellow],
     link: '/torque-power-short.html',
   },
-  {
+  Meteor: {
     name: 'Meteor Workout Short',
     rating: '73%',
     reviews: '3 Reviews',
@@ -237,14 +237,14 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Green],
     link: '/meteor-workout-short.html',
   },
-  {
+  Apollo: {
     name: 'Apollo Running Short',
     price: 'As low as $32.50',
     sizes: Sizes,
     colors: [Colors.Black],
     link: '/apollo-running-short.html',
   },
-  {
+  Cobalt: {
     name: 'Cobalt CoolTech™ Fitness Short',
     rating: '80%',
     reviews: '3 Reviews',
@@ -253,4 +253,19 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/cobalt-cooltech-trade-fitness-short.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Pierce,
+  ProductDetails.Arcadio,
+  ProductDetails.Sol,
+  ProductDetails.Troy,
+  ProductDetails.Orestes,
+  ProductDetails.Rapha,
+  ProductDetails.Lono,
+  ProductDetails.Hawkeye,
+  ProductDetails.Torque,
+  ProductDetails.Meteor,
+  ProductDetails.Apollo,
+  ProductDetails.Cobalt,
 ];

--- a/tests/data/productCategories/menTanks.ts
+++ b/tests/data/productCategories/menTanks.ts
@@ -120,43 +120,43 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Cassius: {
     name: 'Cassius Sparring Tank',
     price: 'As low as $18.00',
     sizes: Sizes,
     colors: [Colors.Blue],
     link: '/cassius-sparring-tank.html',
   },
-  {
+  Atlas: {
     name: 'Atlas Fitness Tank',
     price: 'As low as $18.00',
     sizes: Sizes,
     colors: [Colors.Blue],
     link: '/atlas-fitness-tank.html',
   },
-  {
+  Tiberius: {
     name: 'Tiberius Gym Tank',
     price: 'As low as $18.00',
     sizes: Sizes,
     colors: [Colors.Yellow],
     link: '/tiberius-gym-tank.html',
   },
-  {
+  Sinbad: {
     name: 'Sinbad Fitness Tank',
     price: 'As low as $29.00',
     sizes: Sizes,
     colors: [Colors.Blue],
     link: '/sinbad-fitness-tank.html',
   },
-  {
+  Sparta: {
     name: 'Sparta Gym Tank',
     price: 'As low as $29.00',
     sizes: Sizes,
     colors: [Colors.Green],
     link: '/sparta-gym-tank.html',
   },
-  {
+  Argus: {
     name: 'Argus All-Weather Tank',
     price: 'As low as $22.00',
     sizes: Sizes,
@@ -168,21 +168,21 @@ export const Products: Product[] = [
       sizes: '/m/t/mt07-gray_main_1.jpg',
     },
   },
-  {
+  Vulcan: {
     name: 'Vulcan Weightlifting Tank',
     price: 'As low as $28.00',
     sizes: Sizes,
     colors: [Colors.Black],
     link: '/vulcan-weightlifting-tank.html',
   },
-  {
+  Rocco: {
     name: 'Rocco Gym Tank',
     price: 'As low as $24.00',
     sizes: Sizes,
     colors: [Colors.Blue],
     link: '/rocco-gym-tank.html',
   },
-  {
+  Helios: {
     name: 'Helios Endurance Tank',
     rating: '70%',
     reviews: '4 Reviews',
@@ -191,7 +191,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue],
     link: '/helios-endurance-tank.html',
   },
-  {
+  Primo: {
     name: 'Primo Endurance Tank',
     rating: '53%',
     reviews: '3 Reviews',
@@ -200,7 +200,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Red, Colors.Yellow],
     link: '/primo-endurance-tank.html',
   },
-  {
+  Tristan: {
     name: 'Tristan Endurance Tank',
     rating: '80%',
     reviews: '3 Reviews',
@@ -209,7 +209,7 @@ export const Products: Product[] = [
     colors: [Colors.Grey, Colors.Red, Colors.White],
     link: '/tristan-endurance-tank.html',
   },
-  {
+  Erikssen: {
     name: 'Erikssen CoolTech™ Fitness Tank',
     rating: '55%',
     reviews: '4 Reviews',
@@ -218,4 +218,19 @@ export const Products: Product[] = [
     colors: [Colors.Grey, Colors.Orange, Colors.Red],
     link: '/erikssen-cooltech-trade-fitness-tank.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Cassius,
+  ProductDetails.Atlas,
+  ProductDetails.Tiberius,
+  ProductDetails.Sinbad,
+  ProductDetails.Sparta,
+  ProductDetails.Argus,
+  ProductDetails.Vulcan,
+  ProductDetails.Rocco,
+  ProductDetails.Helios,
+  ProductDetails.Primo,
+  ProductDetails.Tristan,
+  ProductDetails.Erikssen,
 ];

--- a/tests/data/productCategories/menTees.ts
+++ b/tests/data/productCategories/menTees.ts
@@ -121,8 +121,8 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Strike: {
     name: 'Strike Endurance Tee',
     rating: '65%',
     reviews: '4 Reviews',
@@ -131,7 +131,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/strike-endurance-tee.html',
   },
-  {
+  Deion: {
     name: 'Deion Long-Sleeve EverCool™ Tee',
     rating: '67%',
     reviews: '3 Reviews',
@@ -140,7 +140,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Green, Colors.White],
     link: '/deion-long-sleeve-evercool-trade-tee.html',
   },
-  {
+  Logan: {
     name: 'Logan HeatTec® Tee',
     rating: '60%',
     reviews: '3 Reviews',
@@ -149,7 +149,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/logan-heattec-reg-tee.html',
   },
-  {
+  RykerV: {
     name: 'Ryker LumaTech™ Tee (V-neck)',
     rating: '90%',
     reviews: '2 Reviews',
@@ -158,7 +158,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Grey],
     link: '/ryker-lumatech-trade-tee-v-neck.html',
   },
-  {
+  Aero: {
     name: 'Aero Daily Fitness Tee',
     rating: '80%',
     reviews: '3 Reviews',
@@ -167,7 +167,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Brown, Colors.Yellow],
     link: '/aero-daily-fitness-tee.html',
   },
-  {
+  Zoltan: {
     name: 'Zoltan Gym Tee',
     rating: '70%',
     reviews: '2 Reviews',
@@ -176,7 +176,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Green, Colors.Yellow],
     link: '/zoltan-gym-tee.html',
   },
-  {
+  Balboa: {
     name: 'Balboa Persistence Tee',
     rating: '60%',
     reviews: '2 Reviews',
@@ -185,7 +185,7 @@ export const Products: Product[] = [
     colors: [Colors.Grey, Colors.Green, Colors.Orange],
     link: '/balboa-persistence-tee.html',
   },
-  {
+  AtomicCrew: {
     name: 'Atomic Endurance Running Tee (Crew-Neck)',
     rating: '53%',
     reviews: '3 Reviews',
@@ -194,7 +194,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/atomic-endurance-running-tee-crew-neck.html',
   },
-  {
+  AtomicV: {
     name: 'Atomic Endurance Running Tee (V-neck)',
     rating: '80%',
     reviews: '3 Reviews',
@@ -203,7 +203,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Green, Colors.Yellow],
     link: '/atomic-endurance-running-tee-v-neck.html',
   },
-  {
+  RykerCrew: {
     name: 'Ryker LumaTech™ Tee (Crew-neck)',
     rating: '73%',
     reviews: '3 Reviews',
@@ -212,7 +212,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/ryker-lumatech-trade-tee-crew-neck.html',
   },
-  {
+  Helios: {
     name: 'Helios EverCool™ Tee',
     rating: '80%',
     reviews: '3 Reviews',
@@ -221,7 +221,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Purple],
     link: '/helios-evercool-trade-tee.html',
   },
-  {
+  Gobi: {
     name: 'Gobi HeatTec® Tee',
     rating: '67%',
     reviews: '3 Reviews',
@@ -230,4 +230,19 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Orange, Colors.Red],
     link: '/gobi-heattec-reg-tee.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Strike,
+  ProductDetails.Deion,
+  ProductDetails.Logan,
+  ProductDetails.RykerV,
+  ProductDetails.Aero,
+  ProductDetails.Zoltan,
+  ProductDetails.Balboa,
+  ProductDetails.AtomicCrew,
+  ProductDetails.AtomicV,
+  ProductDetails.RykerCrew,
+  ProductDetails.Helios,
+  ProductDetails.Gobi,
 ];

--- a/tests/data/productCategories/womenHoodies.ts
+++ b/tests/data/productCategories/womenHoodies.ts
@@ -261,50 +261,50 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Circe: {
     name: 'Circe Hooded Ice Fleece',
     price: 'As low as $68.00',
     sizes: Sizes,
     colors: [Colors.Grey, Colors.Green, Colors.Purple],
     link: '/circe-hooded-ice-fleece.html',
   },
-  {
+  Eos: {
     name: 'Eos V-Neck Hoodie',
     price: 'As low as $54.00',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Green, Colors.Orange],
     link: '/eos-v-neck-hoodie.html',
   },
-  {
+  Helena: {
     name: 'Helena Hooded Fleece',
     price: 'As low as $55.00',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Grey, Colors.Yellow],
     link: '/helena-hooded-fleece.html',
   },
-  {
+  Ariel: {
     name: 'Ariel Roll Sleeve Sweatshirt',
     price: 'As low as $39.00',
     sizes: Sizes,
     colors: [Colors.Green, Colors.Purple, Colors.Red],
     link: '/ariel-roll-sleeve-sweatshirt.html',
   },
-  {
+  Cassia: {
     name: 'Cassia Funnel Sweatshirt',
     price: 'As low as $48.00',
     sizes: Sizes,
     colors: [Colors.Orange, Colors.Purple, Colors.White],
     link: '/cassia-funnel-sweatshirt.html',
   },
-  {
+  Phoebe: {
     name: 'Phoebe Zipper Sweatshirt',
     price: 'As low as $59.00',
     sizes: Sizes,
     colors: [Colors.Grey, Colors.Purple, Colors.White],
     link: '/phoebe-zipper-sweatshirt.html',
   },
-  {
+  Daphne: {
     name: 'Daphne Full-Zip Hoodie',
     rating: '80%',
     reviews: '2 Reviews',
@@ -313,7 +313,7 @@ export const Products: Product[] = [
     colors: [Colors.Purple],
     link: '/daphne-full-zip-hoodie.html',
   },
-  {
+  Selene: {
     name: 'Selene Yoga Hoodie',
     rating: '80%',
     reviews: '3 Reviews',
@@ -322,7 +322,7 @@ export const Products: Product[] = [
     colors: [Colors.Orange, Colors.Purple, Colors.White],
     link: '/selene-yoga-hoodie.html',
   },
-  {
+  Miko: {
     name: 'Miko Pullover Hoodie',
     rating: '60%',
     reviews: '3 Reviews',
@@ -331,7 +331,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Orange, Colors.Purple],
     link: '/miko-pullover-hoodie.html',
   },
-  {
+  Autumn: {
     name: 'Autumn Pullie',
     rating: '60%',
     reviews: '3 Reviews',
@@ -340,7 +340,7 @@ export const Products: Product[] = [
     colors: [Colors.Green, Colors.Purple, Colors.Red],
     link: '/autumn-pullie.html',
   },
-  {
+  Hera: {
     name: 'Hera Pullover Hoodie',
     rating: '67%',
     reviews: '3 Reviews',
@@ -349,7 +349,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Green, Colors.Orange],
     link: '/hera-pullover-hoodie.html',
   },
-  {
+  Mona: {
     // This is surely a typo but because I want my tests to pass and I can't change the actual product data I have to include the same typo here
     name: 'Mona Pullover Hoodlie',
     rating: '87%',
@@ -359,4 +359,19 @@ export const Products: Product[] = [
     colors: [Colors.Green, Colors.Orange, Colors.Purple],
     link: '/mona-pullover-hoodlie.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Circe,
+  ProductDetails.Eos,
+  ProductDetails.Helena,
+  ProductDetails.Ariel,
+  ProductDetails.Cassia,
+  ProductDetails.Phoebe,
+  ProductDetails.Daphne,
+  ProductDetails.Selene,
+  ProductDetails.Miko,
+  ProductDetails.Autumn,
+  ProductDetails.Hera,
+  ProductDetails.Mona,
 ];

--- a/tests/data/productCategories/womenJackets.ts
+++ b/tests/data/productCategories/womenJackets.ts
@@ -197,15 +197,15 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Olivia: {
     name: 'Olivia 1/4 Zip Light Jacket',
     price: 'As low as $77.00',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Purple],
     link: '/olivia-1-4-zip-light-jacket.html',
   },
-  {
+  Juno: {
     name: 'Juno Jacket',
     rating: '87%',
     reviews: '3 Reviews',
@@ -214,7 +214,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Green, Colors.Purple],
     link: '/juno-jacket.html',
   },
-  {
+  Neve: {
     name: 'Neve Studio Dance Jacket',
     rating: '87%',
     reviews: '3 Reviews',
@@ -223,7 +223,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Orange],
     link: '/neve-studio-dance-jacket.html',
   },
-  {
+  Nadia: {
     name: 'Nadia Elements Shell',
     rating: '60%',
     reviews: '3 Reviews',
@@ -232,7 +232,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Orange, Colors.Yellow],
     link: '/nadia-elements-shell.html',
   },
-  {
+  Jade: {
     name: 'Jade Yoga Jacket',
     rating: '87%',
     reviews: '3 Reviews',
@@ -241,7 +241,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Grey, Colors.Green],
     link: '/jade-yoga-jacket.html',
   },
-  {
+  Adrienne: {
     name: 'Adrienne Trek Jacket',
     rating: '60%',
     reviews: '2 Reviews',
@@ -250,7 +250,7 @@ export const Products: Product[] = [
     colors: [Colors.Grey, Colors.Orange, Colors.Purple],
     link: '/adrienne-trek-jacket.html',
   },
-  {
+  Inez: {
     name: 'Inez Full Zip Jacket',
     rating: '67%',
     reviews: '3 Reviews',
@@ -259,7 +259,7 @@ export const Products: Product[] = [
     colors: [Colors.Orange, Colors.Purple, Colors.Red],
     link: '/inez-full-zip-jacket.html',
   },
-  {
+  Riona: {
     name: 'Riona Full Zip Jacket',
     rating: '87%',
     reviews: '3 Reviews',
@@ -268,7 +268,7 @@ export const Products: Product[] = [
     colors: [Colors.Brown, Colors.Green, Colors.Red],
     link: '/riona-full-zip-jacket.html',
   },
-  {
+  Ingrid: {
     name: 'Ingrid Running Jacket',
     rating: '90%',
     reviews: '2 Reviews',
@@ -277,7 +277,7 @@ export const Products: Product[] = [
     colors: [Colors.Orange, Colors.Red, Colors.White],
     link: '/ingrid-running-jacket.html',
   },
-  {
+  Augusta: {
     name: 'Augusta Pullover Jacket',
     rating: '87%',
     reviews: '3 Reviews',
@@ -286,7 +286,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Orange, Colors.Red],
     link: '/augusta-pullover-jacket.html',
   },
-  {
+  Josie: {
     name: 'Josie Yoga Jacket',
     rating: '70%',
     reviews: '4 Reviews',
@@ -295,7 +295,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Grey],
     link: '/josie-yoga-jacket.html',
   },
-  {
+  Stellar: {
     name: 'Stellar Solar Jacket',
     rating: '67%',
     reviews: '3 Reviews',
@@ -304,4 +304,19 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Red, Colors.Yellow],
     link: '/stellar-solar-jacket.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Olivia,
+  ProductDetails.Juno,
+  ProductDetails.Neve,
+  ProductDetails.Nadia,
+  ProductDetails.Jade,
+  ProductDetails.Adrienne,
+  ProductDetails.Inez,
+  ProductDetails.Riona,
+  ProductDetails.Ingrid,
+  ProductDetails.Augusta,
+  ProductDetails.Josie,
+  ProductDetails.Stellar,
 ];

--- a/tests/data/productCategories/womenPants.ts
+++ b/tests/data/productCategories/womenPants.ts
@@ -169,57 +169,57 @@ export const Filters: FilterCategory[] = [
 
 const Sizes = ['28', '29'];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Portia: {
     name: 'Portia Capri',
     price: 'As low as $39.20',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Green, Colors.Orange],
     link: '/portia-capri.html',
   },
-  {
+  Deirdre: {
     name: 'Deirdre Relaxed-Fit Capri',
     price: 'As low as $50.40',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Grey, Colors.Green],
     link: '/deirdre-relaxed-fit-capri.html',
   },
-  {
+  Sylvia: {
     name: 'Sylvia Capri',
     price: 'As low as $33.60',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Green, Colors.Red],
     link: '/sylvia-capri.html',
   },
-  {
+  Daria: {
     name: 'Daria Bikram Pant',
     price: 'As low as $40.80',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Grey, Colors.White],
     link: '/daria-bikram-pant.html',
   },
-  {
+  Carina: {
     name: 'Carina Basic Capri',
     price: 'As low as $40.80',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Purple],
     link: '/carina-basic-capri.html',
   },
-  {
+  Bardot: {
     name: 'Bardot Capri',
     price: 'As low as $38.40',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Green, Colors.Red],
     link: '/bardot-capri.html',
   },
-  {
+  Aeon: {
     name: 'Aeon Capri',
     price: 'As low as $38.40',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Blue, Colors.Orange],
     link: '/aeon-capri.html',
   },
-  {
+  Diana: {
     name: 'Diana Tights',
     rating: '67%',
     reviews: '3 Reviews',
@@ -228,7 +228,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Orange],
     link: '/diana-tights.html',
   },
-  {
+  Sahara: {
     name: 'Sahara Leggings',
     rating: '60%',
     reviews: '2 Reviews',
@@ -237,7 +237,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Grey, Colors.Red],
     link: '/sahara-leggings.html',
   },
-  {
+  Cora: {
     name: 'Cora Parachute Pant',
     rating: '80%',
     reviews: '4 Reviews',
@@ -246,7 +246,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.White],
     link: '/cora-parachute-pant.html',
   },
-  {
+  Ida: {
     name: 'Ida Workout Parachute Pant',
     rating: '67%',
     reviews: '3 Reviews',
@@ -255,7 +255,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Purple],
     link: '/ida-workout-parachute-pant.html',
   },
-  {
+  Emma: {
     name: 'Emma Leggings',
     rating: '93%',
     reviews: '3 Reviews',
@@ -264,7 +264,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Purple, Colors.Red],
     link: '/emma-leggings.html',
   },
-  {
+  Karmen: {
     name: 'Karmen Yoga Pant',
     rating: '80%',
     reviews: '2 Reviews',
@@ -273,4 +273,20 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Grey, Colors.White],
     link: '/karmen-yoga-pant.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Portia,
+  ProductDetails.Deirdre,
+  ProductDetails.Sylvia,
+  ProductDetails.Daria,
+  ProductDetails.Carina,
+  ProductDetails.Bardot,
+  ProductDetails.Aeon,
+  ProductDetails.Diana,
+  ProductDetails.Sahara,
+  ProductDetails.Cora,
+  ProductDetails.Ida,
+  ProductDetails.Emma,
+  ProductDetails.Karmen,
 ];

--- a/tests/data/productCategories/womenSale.ts
+++ b/tests/data/productCategories/womenSale.ts
@@ -1,9 +1,9 @@
 import { FilterCategory, ProductCategoryExpectedText } from './shared';
-import { Products as WomenHoodies } from './womenHoodies';
-import { Products as WomenJackets } from './womenJackets';
-import { Products as WomenShorts } from './womenShorts';
-import { Products as WomenTanks } from './womenTanks';
-import { Products as WomenTees } from './womenTees';
+import { ProductDetails as WomenHoodies } from './womenHoodies';
+import { ProductDetails as WomenJackets } from './womenJackets';
+import { ProductDetails as WomenShorts } from './womenShorts';
+import { ProductDetails as WomenTanks } from './womenTanks';
+import { ProductDetails as WomenTees } from './womenTees';
 import { Product } from '../products';
 
 export const ExpectedText: ProductCategoryExpectedText = {
@@ -157,18 +157,18 @@ export const Filters: FilterCategory[] = [
 ];
 
 export const Products: Product[] = [
-  WomenShorts[7],
-  WomenShorts[10],
-  WomenTanks[0],
-  WomenTanks[1],
-  WomenTanks[13],
-  WomenTees[3],
-  WomenTees[5],
-  WomenTees[6],
-  WomenJackets[0],
-  WomenJackets[1],
-  WomenJackets[5],
-  WomenJackets[10],
-  WomenHoodies[4],
-  WomenHoodies[10],
+  WomenShorts.Bess,
+  WomenShorts.Maxima,
+  WomenTanks.BreatheEasy,
+  WomenTanks.Antonia,
+  WomenTanks.Electra,
+  WomenTees.Diva,
+  WomenTees.Tiffany,
+  WomenTees.Minerva,
+  WomenJackets.Olivia,
+  WomenJackets.Juno,
+  WomenJackets.Adrienne,
+  WomenJackets.Josie,
+  WomenHoodies.Cassia,
+  WomenHoodies.Hera,
 ];

--- a/tests/data/productCategories/womenShorts.ts
+++ b/tests/data/productCategories/womenShorts.ts
@@ -167,8 +167,8 @@ export const Filters: FilterCategory[] = [
 
 const Sizes = { All: ['28', '29', '30', '31', '32'], Small: ['28', '29'] };
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Erika: {
     name: 'Erika Running Short',
     rating: '60%',
     reviews: '3 Reviews',
@@ -177,7 +177,7 @@ export const Products: Product[] = [
     colors: [Colors.Green, Colors.Purple, Colors.Red],
     link: '/erika-running-short.html',
   },
-  {
+  Ina: {
     name: 'Ina Compression Short',
     rating: '73%',
     reviews: '3 Reviews',
@@ -186,7 +186,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Orange, Colors.Red],
     link: '/ina-compression-short.html',
   },
-  {
+  Ana: {
     name: 'Ana Running Short',
     rating: '80%',
     reviews: '3 Reviews',
@@ -195,7 +195,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Orange, Colors.White],
     link: '/ana-running-short.html',
   },
-  {
+  Mimi: {
     name: 'Mimi All-Purpose Short',
     rating: '67%',
     reviews: '3 Reviews',
@@ -204,7 +204,7 @@ export const Products: Product[] = [
     colors: [Colors.Grey, Colors.Green, Colors.White],
     link: '/mimi-all-purpose-short.html',
   },
-  {
+  Sybil: {
     name: 'Sybil Running Short',
     rating: '93%',
     reviews: '3 Reviews',
@@ -213,7 +213,7 @@ export const Products: Product[] = [
     colors: [Colors.Purple],
     link: '/sybil-running-short.html',
   },
-  {
+  Echo: {
     name: 'Echo Fit Compression Short',
     rating: '67%',
     reviews: '3 Reviews',
@@ -222,7 +222,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Purple],
     link: '/echo-fit-compression-short.html',
   },
-  {
+  Angel: {
     name: 'Angel Light Running Short',
     rating: '70%',
     reviews: '2 Reviews',
@@ -231,7 +231,7 @@ export const Products: Product[] = [
     colors: [Colors.Grey, Colors.Orange, Colors.Purple],
     link: '/angel-light-running-short.html',
   },
-  {
+  Bess: {
     name: 'Bess Yoga Short',
     rating: '73%',
     reviews: '3 Reviews',
@@ -240,7 +240,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Purple, Colors.Yellow],
     link: '/bess-yoga-short.html',
   },
-  {
+  Artemis: {
     name: 'Artemis Running Short',
     rating: '80%',
     reviews: '2 Reviews',
@@ -249,7 +249,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Green, Colors.Orange],
     link: '/artemis-running-short.html',
   },
-  {
+  Gwen: {
     name: 'Gwen Drawstring Bike Short',
     rating: '90%',
     reviews: '2 Reviews',
@@ -258,7 +258,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Grey, Colors.Orange],
     link: '/gwen-drawstring-bike-short.html',
   },
-  {
+  Maxima: {
     name: 'Maxima Drawstring Short',
     rating: '80%',
     reviews: '3 Reviews',
@@ -267,7 +267,7 @@ export const Products: Product[] = [
     colors: [Colors.Grey, Colors.Orange, Colors.Yellow],
     link: '/maxima-drawstring-short.html',
   },
-  {
+  Fiona: {
     name: 'Fiona Fitness Short',
     rating: '60%',
     reviews: '3 Reviews',
@@ -276,4 +276,19 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Green, Colors.Red],
     link: '/fiona-fitness-short.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Erika,
+  ProductDetails.Ina,
+  ProductDetails.Ana,
+  ProductDetails.Mimi,
+  ProductDetails.Sybil,
+  ProductDetails.Echo,
+  ProductDetails.Angel,
+  ProductDetails.Bess,
+  ProductDetails.Artemis,
+  ProductDetails.Gwen,
+  ProductDetails.Maxima,
+  ProductDetails.Fiona,
 ];

--- a/tests/data/productCategories/womenTanks.ts
+++ b/tests/data/productCategories/womenTanks.ts
@@ -273,7 +273,7 @@ export const ProductDetails: Record<string, Product> = {
 };
 
 export const Products = [
-  ProductDetails.BreathEasy,
+  ProductDetails.BreatheEasy,
   ProductDetails.Antonia,
   ProductDetails.Maya,
   ProductDetails.Chloe,

--- a/tests/data/productCategories/womenTanks.ts
+++ b/tests/data/productCategories/womenTanks.ts
@@ -144,8 +144,8 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  BreatheEasy: {
     name: 'Breathe-Easy Tank',
     rating: '70%',
     reviews: '2 Reviews',
@@ -159,7 +159,7 @@ export const Products: Product[] = [
       sizes: '/w/t/wt09-purple_main_1.jpg',
     },
   },
-  {
+  Antonia: {
     name: 'Antonia Racer Tank',
     rating: '60%',
     reviews: '3 Reviews',
@@ -168,7 +168,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Purple, Colors.Yellow],
     link: '/antonia-racer-tank.html',
   },
-  {
+  Maya: {
     name: 'Maya Tunic',
     rating: '80%',
     reviews: '1 Review',
@@ -177,7 +177,7 @@ export const Products: Product[] = [
     colors: [Colors.Green, Colors.White, Colors.Yellow],
     link: '/maya-tunic.html',
   },
-  {
+  Chloe: {
     name: 'Chloe Compete Tank',
     rating: '73%',
     reviews: '3 Reviews',
@@ -186,28 +186,28 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Red, Colors.Yellow],
     link: '/chloe-compete-tank.html',
   },
-  {
+  Leah: {
     name: 'Leah Yoga Top',
     price: 'As low as $39.00',
     sizes: Sizes,
     colors: [Colors.Orange, Colors.Purple, Colors.White],
     link: '/leah-yoga-top.html',
   },
-  {
+  Nona: {
     name: 'Nona Fitness Tank',
     price: 'As low as $39.00',
     sizes: Sizes,
     colors: [Colors.Blue, Colors.Purple, Colors.Red],
     link: '/nona-fitness-tank.html',
   },
-  {
+  Nora: {
     name: 'Nora Practice Tank',
     price: 'As low as $39.00',
     sizes: Sizes,
     colors: [Colors.Orange, Colors.Purple, Colors.Red],
     link: '/nora-practice-tank.html',
   },
-  {
+  Zoe: {
     name: 'Zoe Tank',
     rating: '53%',
     reviews: '3 Reviews',
@@ -216,7 +216,7 @@ export const Products: Product[] = [
     colors: [Colors.Green, Colors.Orange, Colors.Yellow],
     link: '/zoe-tank.html',
   },
-  {
+  Bella: {
     name: 'Bella Tank',
     rating: '80%',
     reviews: '2 Reviews',
@@ -225,7 +225,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Orange],
     link: '/bella-tank.html',
   },
-  {
+  Lucia: {
     name: 'Lucia Cross-Fit Bra',
     rating: '40%',
     reviews: '3 Reviews',
@@ -234,7 +234,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Orange, Colors.Purple],
     link: '/lucia-cross-fit-bra.html',
   },
-  {
+  Prima: {
     name: 'Prima Compete Bra Top',
     rating: '60%',
     reviews: '3 Reviews',
@@ -243,7 +243,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Purple, Colors.Yellow],
     link: '/prima-compete-bra-top.html',
   },
-  {
+  Celeste: {
     name: 'Celeste Sports Bra',
     rating: '67%',
     reviews: '3 Reviews',
@@ -252,7 +252,7 @@ export const Products: Product[] = [
     colors: [Colors.Green, Colors.Red, Colors.Yellow],
     link: '/celeste-sports-bra.html',
   },
-  {
+  Erica: {
     name: 'Erica Evercool Sports Bra',
     rating: '60%',
     reviews: '4 Reviews',
@@ -261,7 +261,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Orange, Colors.Yellow],
     link: '/erica-evercool-sports-bra.html',
   },
-  {
+  Electra: {
     name: 'Electra Bra Top',
     rating: '75%',
     reviews: '4 Reviews',
@@ -270,4 +270,21 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Grey, Colors.Purple],
     link: '/electra-bra-top.html',
   },
+};
+
+export const Products = [
+  ProductDetails.BreathEasy,
+  ProductDetails.Antonia,
+  ProductDetails.Maya,
+  ProductDetails.Chloe,
+  ProductDetails.Leah,
+  ProductDetails.Nona,
+  ProductDetails.Nora,
+  ProductDetails.Zoe,
+  ProductDetails.Bella,
+  ProductDetails.Lucia,
+  ProductDetails.Prima,
+  ProductDetails.Celeste,
+  ProductDetails.Erica,
+  ProductDetails.Electra,
 ];

--- a/tests/data/productCategories/womenTees.ts
+++ b/tests/data/productCategories/womenTees.ts
@@ -122,8 +122,8 @@ export const Filters: FilterCategory[] = [
   },
 ];
 
-export const Products: Product[] = [
-  {
+export const ProductDetails: Record<string, Product> = {
+  Desiree: {
     name: 'Desiree Fitness Tee',
     rating: '73%',
     reviews: '3 Reviews',
@@ -132,7 +132,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Orange, Colors.Yellow],
     link: '/desiree-fitness-tee.html',
   },
-  {
+  Gwyn: {
     name: 'Gwyn Endurance Tee',
     rating: '87%',
     reviews: '3 Reviews',
@@ -141,7 +141,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Green, Colors.Yellow],
     link: '/gwyn-endurance-tee.html',
   },
-  {
+  Radiant: {
     name: 'Radiant Tee',
     rating: '60%',
     reviews: '3 Reviews',
@@ -162,7 +162,7 @@ export const Products: Product[] = [
       ],
     },
   },
-  {
+  Diva: {
     name: 'Diva Gym Tee',
     rating: '87%',
     reviews: '3 Reviews',
@@ -171,7 +171,7 @@ export const Products: Product[] = [
     colors: [Colors.Green, Colors.Orange, Colors.Yellow],
     link: '/diva-gym-tee.html',
   },
-  {
+  Karissa: {
     name: 'Karissa V-Neck Tee',
     rating: '80%',
     reviews: '3 Reviews',
@@ -180,7 +180,7 @@ export const Products: Product[] = [
     colors: [Colors.Green, Colors.Red, Colors.Yellow],
     link: '/karissa-v-neck-tee.html',
   },
-  {
+  Tiffany: {
     name: 'Tiffany Fitness Tee',
     rating: '73%',
     reviews: '3 Reviews',
@@ -189,7 +189,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Red, Colors.White],
     link: '/tiffany-fitness-tee.html',
   },
-  {
+  Minerva: {
     name: 'Minerva LumaTech™ V-Tee',
     rating: '47%',
     reviews: '3 Reviews',
@@ -198,7 +198,7 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.Blue, Colors.Red],
     link: '/minerva-lumatech-trade-v-tee.html',
   },
-  {
+  Juliana: {
     name: 'Juliana Short-Sleeve Tee',
     rating: '60%',
     reviews: '2 Reviews',
@@ -207,14 +207,14 @@ export const Products: Product[] = [
     colors: [Colors.Black, Colors.White, Colors.Yellow],
     link: '/juliana-short-sleeve-tee.html',
   },
-  {
+  Elisa: {
     name: 'Elisa EverCool™ Tee',
     price: 'As low as $29.00',
     sizes: Sizes,
     colors: [Colors.Grey, Colors.Purple, Colors.Red],
     link: '/elisa-evercool-trade-tee.html',
   },
-  {
+  Layla: {
     name: 'Layla Tee',
     rating: '60%',
     reviews: '2 Reviews',
@@ -223,7 +223,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Green, Colors.Red],
     link: '/layla-tee.html',
   },
-  {
+  Iris: {
     name: 'Iris Workout Top',
     rating: '60%',
     reviews: '4 Reviews',
@@ -232,7 +232,7 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Green, Colors.Red],
     link: '/iris-workout-top.html',
   },
-  {
+  Gabrielle: {
     name: 'Gabrielle Micro Sleeve Top',
     rating: '73%',
     reviews: '3 Reviews',
@@ -241,4 +241,19 @@ export const Products: Product[] = [
     colors: [Colors.Blue, Colors.Green, Colors.Red],
     link: '/gabrielle-micro-sleeve-top.html',
   },
+};
+
+export const Products = [
+  ProductDetails.Desiree,
+  ProductDetails.Gwyn,
+  ProductDetails.Radiant,
+  ProductDetails.Diva,
+  ProductDetails.Karissa,
+  ProductDetails.Tiffany,
+  ProductDetails.Minerva,
+  ProductDetails.Juliana,
+  ProductDetails.Elisa,
+  ProductDetails.Layla,
+  ProductDetails.Iris,
+  ProductDetails.Gabrielle,
 ];


### PR DESCRIPTION
To (hopefully) help with some upcoming work I have reworked the way test data is managed for products, primarily switching the product details data to objects rather than arrays. This allows products to be referenced by their key rather array index, which is obviously easier to manage and clearer to review & maintain going forwards. As a result of switching to objects I have had to introduce a new array for each product category that defines the order in which the products are arranged but I think this is preferable to the old method. The acid test will come a bit later when I add tests for the individual product pages as hopefully now it will be easier to reference individual products without needing to use hardcoded array references that would change should the order of products in the store change.