### PR TITLE
Make Page Size test less flaky

### DIFF
--- a/tests/specs/productCategoryPage.spec.ts
+++ b/tests/specs/productCategoryPage.spec.ts
@@ -560,10 +560,12 @@ for (const lvl0Category of getProductCategories(0)) {
             // The test is flaky on Firefox, presumably due to the slow navigation, so skip it
             testInfo.skip(browserName === 'firefox', 'Skip flaky test on Firefox');
             for (const pageSize of ExpectedText.PageSizes.Grid) {
-              let productDetails = [...Products[category]];
+              let productDetails = [...Products[category]].slice(0, pageSize);
               const queryParams = pageSize === 12 ? '' : `?${QueryParams.PageSize}=${pageSize}`;
-              await productCategoryPage.pageSizeDropdown.selectOption(pageSize.toString());
-              productDetails = productDetails.slice(0, pageSize);
+              do {
+                await productCategoryPage.pageSizeDropdown.selectOption(pageSize.toString());
+                await productCategoryPage.page.waitForLoadState('domcontentloaded');
+              } while (!productCategoryPage.page.url().endsWith(queryParams));
               await expect(productCategoryPage.page).toHaveURL(`${baseURL}${url}${queryParams}`);
               const productItems = productCategoryPage.productItem;
               await expect.soft(productItems).toHaveCount(productDetails.length);


### PR DESCRIPTION
For some reason the Product Category > MenSale > Page Size test seems to be flaky on Chromium (the URL assertion sometimes failing after selecting the page size) yet it is fine on Webkit and Firefox. I can reproduce the flake locally, which is something, but exactly how to address it has proven a bit tricky. I have put the page size selection in a `do-while` loop so that it retries if the URL doesn't end in the expected query params but even this can fail at times locally (the select element isn't visible/selectable for reasons I don't understand). Despite that, I hope I have reduced if not entirely eliminated the flake associated with this test