### PR TITLE
Change default collection page

### DIFF
--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -10,7 +10,7 @@ const Timeouts = {
 };
 
 dotenv.config();
-const pages = process.env.TEST_MODE === 'full' ? Object.keys(Collections) : ['WhatsNew'];
+const pages = process.env.TEST_MODE === 'full' ? Object.keys(Collections) : ['Women'];
 for (const collection of pages) {
   test.describe(`${collection} page tests`, () => {
     let collectionPage: CollectionPage;


### PR DESCRIPTION
Previously I was using "What's New" as the default collection page. This means when we run a subset of the tests (as we do for PRs, for example) that we are limiting the relevant spec to only testing the default page and as several tests are skipped for that page for various reasons we are running fewer tests than we should be really. By changing the default page to something else - and I was only using "What's New" because it was first in the topnav - we will run the full set of tests for the new default page and thus have a bit better coverage when running a limited subset of tests which will give a bit more confidence in PR'ed changes