### PR TITLE
Extend product page tests to more products

### DIFF
--- a/tests/data/productCategories/gearBags.ts
+++ b/tests/data/productCategories/gearBags.ts
@@ -173,9 +173,40 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Fusion Backpack',
     rating: '67%',
     reviews: '3 Reviews',
+    inStock: true,
+    sku: '24-MB02',
     price: '$59.00',
     link: '/fusion-backpack.html',
-    images: { default: '/m/b/mb02-gray-0.jpg' },
+    images: { default: '/m/b/mb02-gray-0.jpg', thumbnails: ['/m/b/mb02-gray-0.jpg', '/m/b/mb02-blue-0.jpg'] },
+    description: `With the Fusion Backpack strapped on, every trek is an adventure - even a bus ride to work. That's partly because two large zippered compartments store everything you need, while a front zippered pocket and side mesh pouches are perfect for stashing those little extras, in case you change your mind and take the day off.\n\nDurable nylon construction.\n2 main zippered compartments.\n1 exterior zippered pocket.\nMesh side pouches.\nPadded, adjustable straps.\nTop carry handle.\nDimensions: 18" x 10" x 6".`,
+    additionalInfo:
+      'Activity\tYoga, Hiking, School\nStyle\tBackpack, Laptop\nMaterial\tBurlap, Nylon, Polyester\nStrap/Handle\tAdjustable, Double, Padded\nFeatures\tHydration Pocket, Audio Pocket, Waterproof, Lightweight',
+    reviewDetails: [
+      {
+        title: "I've had this thing for really long",
+        rating: '100%',
+        reviewText:
+          "I've had this thing for a really long time and it barely shows any signs of wear and tear. It's really big, too! I've taken it on day trips as well as short vacations and usually have no trouble finding room for my stuff.",
+        reviewer: 'Herb',
+        date: '3/11/23',
+      },
+      {
+        title: 'Decent bag',
+        rating: '60%',
+        reviewText:
+          "Decent bag. I keep my stuff in it for work and the gym. It's nice and roomy. I wish it had a more sophisticated design, though. Kinda looks like it's for kids.",
+        reviewer: 'Craig',
+        date: '3/11/23',
+      },
+      {
+        title: 'Screwed up my back',
+        rating: '40%',
+        reviewText:
+          'I can\'t believe they\'re claiming these straps are "padded." Wearing this thing to class for a semester totally screwed up my back, and my shoulders would start to ache after a few minutes where the straps dug in.',
+        reviewer: 'Orville',
+        date: '3/11/23',
+      },
+    ],
   },
   Rival: {
     name: 'Rival Field Messenger',

--- a/tests/data/productCategories/gearBags.ts
+++ b/tests/data/productCategories/gearBags.ts
@@ -116,9 +116,41 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Push It Messenger Bag',
     rating: '67%',
     reviews: '3 Reviews',
+    inStock: true,
+    sku: '24-WB04',
     price: '$45.00',
     link: '/push-it-messenger-bag.html',
     images: { default: '/w/b/wb04-blue-0.jpg' },
+    description:
+      "The name says so, but the Push It Messenger Bag is much more than a busy commuter's tote. It's a closet away from home when you're pedaling from class or work to gym and back or home again. It's the perfect size and shape for laptop, folded clothes, even extra shoes.\n\nAdjustable crossbody strap.\nTop handle.\nZippered interior pocket.\nSecure clip closures.\nDurable fabric construction.",
+    additionalInfo:
+      'Activity\tYoga, School, Urban\nStyle\tMessenger, Laptop\nMaterial\tNylon, Polyester\nStrap/Handle\tAdjustable, Cross Body, Detachable, Padded, Shoulder, Single\nFeatures\tWaterproof, Lightweight, Laptop Sleeve, Lockable',
+    reviewDetails: [
+      {
+        title: 'I bike four miles a day to work and back',
+        rating: '80%',
+        reviewText:
+          "I bike four miles a day to work and back and I love this thing. It's a good size and it's pretty comfortable to wear across my back while I ride. So far I have not noticed much wear and tear on the fabric and I've had it for 6 months.",
+        reviewer: 'Sadye',
+        date: '3/11/23',
+      },
+      {
+        title: 'I would love this bag EXCEPT . . .',
+        rating: '60%',
+        reviewText:
+          "I would love this bag EXCEPT with the case on my Iphone won't fit in the cell phone pocket! Why make a pocket for cell phones if it's not going to fit an Iphone.",
+        reviewer: 'Adena',
+        date: '3/11/23',
+      },
+      {
+        title: "it's really ugly,",
+        rating: '60%',
+        reviewText:
+          "Its fine I guess but it's really ugly, I picked out a really cute bag for college but my mom got me this one instead.",
+        reviewer: 'Tracee',
+        date: '3/11/23',
+      },
+    ],
   },
   Overnight: {
     name: 'Overnight Duffle',

--- a/tests/data/productCategories/menHoodies.ts
+++ b/tests/data/productCategories/menHoodies.ts
@@ -252,7 +252,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Hero Hoodie',
     price: 'As low as $54.00',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Grey, Colors.Green],
+    colors: [Colors.Black, Colors.Gray, Colors.Green],
     link: '/hero-hoodie.html',
     images: {
       default: '/m/h/mh07-gray_main_2.jpg',
@@ -306,7 +306,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Chaz Kangeroo Hoodie',
     price: 'As low as $52.00',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Grey, Colors.Orange],
+    colors: [Colors.Black, Colors.Gray, Colors.Orange],
     link: '/chaz-kangeroo-hoodie.html',
   },
 };

--- a/tests/data/productCategories/menHoodies.ts
+++ b/tests/data/productCategories/menHoodies.ts
@@ -251,11 +251,14 @@ export const ProductDetails: Record<string, Product> = {
   Hero: {
     name: 'Hero Hoodie',
     price: 'As low as $54.00',
+    inStock: true,
+    sku: 'MH07',
     sizes: Sizes,
     colors: [Colors.Black, Colors.Gray, Colors.Green],
     link: '/hero-hoodie.html',
     images: {
       default: '/m/h/mh07-gray_main_2.jpg',
+      thumbnails: ['/m/h/mh07-gray_main_2.jpg', '/m/h/mh07-gray_alt1_2.jpg', '/m/h/mh07-gray_back_2.jpg'],
       colors: ['/m/h/mh07-black_main_1.jpg', '/m/h/mh07-gray_main_1.jpg', '/m/h/mh07-green_main_1.jpg'],
       // The hoodie has 2 different images for the size options
       sizes: [
@@ -266,6 +269,9 @@ export const ProductDetails: Record<string, Product> = {
         '/m/h/mh07-black_main_2.jpg',
       ],
     },
+    description:
+      'Gray and black color blocking sets you apart as the Hero Hoodie keeps you warm on the bus, campus or cold mean streets. Slanted outsize front pockets keep your style real . . . convenient.\n\n• Full-zip gray and black hoodie.\n• Ribbed hem.\n• Standard fit.\n• Drawcord hood cinch.\n• Water-resistant coating.',
+    additionalInfo: 'Material\tFleece, Hemp, Polyester\nPattern\tColor-Blocked\nClimate\tSpring',
   },
   Stark: {
     name: 'Stark Fundamental Hoodie',

--- a/tests/data/productCategories/menJackets.ts
+++ b/tests/data/productCategories/menJackets.ts
@@ -208,7 +208,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $99.00',
     sizes: Sizes,
-    colors: [Colors.Blue, Colors.Grey, Colors.Green],
+    colors: [Colors.Blue, Colors.Gray, Colors.Green],
     link: '/lando-gym-jacket.html',
   },
   Orion: {

--- a/tests/data/productCategories/menPants.ts
+++ b/tests/data/productCategories/menPants.ts
@@ -194,7 +194,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Mithra Warmup Pant',
     price: 'As low as $22.40',
     sizes: Sizes,
-    colors: [Colors.Grey, Colors.Green, Colors.Orange],
+    colors: [Colors.Gray, Colors.Green, Colors.Orange],
     link: '/mithra-warmup-pant.html',
   },
   Kratos: {
@@ -212,7 +212,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $36.00',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Grey, Colors.Green],
+    colors: [Colors.Black, Colors.Gray, Colors.Green],
     link: '/supernova-sport-pant.html',
   },
   Geo: {
@@ -230,7 +230,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $36.80',
     sizes: Sizes,
-    colors: [Colors.Blue, Colors.Grey, Colors.Red],
+    colors: [Colors.Blue, Colors.Gray, Colors.Red],
     link: '/viktor-lumatech-trade-pant.html',
   },
   Caesar: {
@@ -239,7 +239,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $28.00',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Grey, Colors.Purple],
+    colors: [Colors.Black, Colors.Gray, Colors.Purple],
     link: '/caesar-warm-up-pant.html',
   },
 };

--- a/tests/data/productCategories/menShorts.ts
+++ b/tests/data/productCategories/menShorts.ts
@@ -157,7 +157,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Pierce Gym Short',
     price: 'As low as $27.00',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Grey, Colors.Red],
+    colors: [Colors.Black, Colors.Gray, Colors.Red],
     link: '/pierce-gym-short.html',
   },
   Arcadio: {
@@ -207,7 +207,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '2 Reviews',
     price: 'As low as $32.00',
     sizes: Sizes,
-    colors: [Colors.Blue, Colors.Grey, Colors.Red],
+    colors: [Colors.Blue, Colors.Gray, Colors.Red],
     link: '/lono-yoga-short.html',
   },
   Hawkeye: {
@@ -216,7 +216,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $29.00',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Blue, Colors.Grey],
+    colors: [Colors.Black, Colors.Blue, Colors.Gray],
     link: '/hawkeye-yoga-short.html',
   },
   Torque: {
@@ -225,7 +225,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $32.50',
     sizes: Sizes,
-    colors: [Colors.Grey, Colors.Purple, Colors.Yellow],
+    colors: [Colors.Gray, Colors.Purple, Colors.Yellow],
     link: '/torque-power-short.html',
   },
   Meteor: {

--- a/tests/data/productCategories/menTanks.ts
+++ b/tests/data/productCategories/menTanks.ts
@@ -160,7 +160,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Argus All-Weather Tank',
     price: 'As low as $22.00',
     sizes: Sizes,
-    colors: [Colors.Grey],
+    colors: [Colors.Gray],
     link: '/argus-all-weather-tank.html',
     images: {
       default: '/m/t/mt07-gray_main_1.jpg',
@@ -206,7 +206,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $29.00',
     sizes: Sizes,
-    colors: [Colors.Grey, Colors.Red, Colors.White],
+    colors: [Colors.Gray, Colors.Red, Colors.White],
     link: '/tristan-endurance-tank.html',
   },
   Erikssen: {
@@ -215,7 +215,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '4 Reviews',
     price: 'As low as $29.00',
     sizes: Sizes,
-    colors: [Colors.Grey, Colors.Orange, Colors.Red],
+    colors: [Colors.Gray, Colors.Orange, Colors.Red],
     link: '/erikssen-cooltech-trade-fitness-tank.html',
   },
 };

--- a/tests/data/productCategories/menTanks.ts
+++ b/tests/data/productCategories/menTanks.ts
@@ -159,14 +159,21 @@ export const ProductDetails: Record<string, Product> = {
   Argus: {
     name: 'Argus All-Weather Tank',
     price: 'As low as $22.00',
+    inStock: true,
+    sku: 'MT07',
     sizes: Sizes,
     colors: [Colors.Gray],
     link: '/argus-all-weather-tank.html',
     images: {
       default: '/m/t/mt07-gray_main_1.jpg',
+      thumbnails: ['/m/t/mt07-gray_main_1.jpg', '/m/t/mt07-gray_back_1.jpg'],
       colors: ['/m/t/mt07-gray_main_1.jpg'],
       sizes: '/m/t/mt07-gray_main_1.jpg',
     },
+    description:
+      'The Argus All-Weather Tank is sure to become your favorite base layer or go-to cover for hot outdoor workouts. With its subtle reflective safely trim, you can even wear it jogging on urban evenings.\n\n• Dark gray polyester spandex tank.\n• Reflective details for nighttime visibility.\n• Stash pocket.\n• Anti-chafe flatlock seams.',
+    additionalInfo:
+      'Style\tTank\nMaterial\tPolyester, Organic Cotton\nPattern\tSolid\nClimate\tAll-Weather, Indoor, Warm',
   },
   Vulcan: {
     name: 'Vulcan Weightlifting Tank',

--- a/tests/data/productCategories/menTees.ts
+++ b/tests/data/productCategories/menTees.ts
@@ -155,7 +155,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '2 Reviews',
     price: 'As low as $28.00',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Blue, Colors.Grey],
+    colors: [Colors.Black, Colors.Blue, Colors.Gray],
     link: '/ryker-lumatech-trade-tee-v-neck.html',
   },
   Aero: {
@@ -182,7 +182,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '2 Reviews',
     price: 'As low as $29.00',
     sizes: Sizes,
-    colors: [Colors.Grey, Colors.Green, Colors.Orange],
+    colors: [Colors.Gray, Colors.Green, Colors.Orange],
     link: '/balboa-persistence-tee.html',
   },
   AtomicCrew: {

--- a/tests/data/productCategories/womenHoodies.ts
+++ b/tests/data/productCategories/womenHoodies.ts
@@ -266,7 +266,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Circe Hooded Ice Fleece',
     price: 'As low as $68.00',
     sizes: Sizes,
-    colors: [Colors.Grey, Colors.Green, Colors.Purple],
+    colors: [Colors.Gray, Colors.Green, Colors.Purple],
     link: '/circe-hooded-ice-fleece.html',
   },
   Eos: {
@@ -280,7 +280,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Helena Hooded Fleece',
     price: 'As low as $55.00',
     sizes: Sizes,
-    colors: [Colors.Blue, Colors.Grey, Colors.Yellow],
+    colors: [Colors.Blue, Colors.Gray, Colors.Yellow],
     link: '/helena-hooded-fleece.html',
   },
   Ariel: {
@@ -301,7 +301,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Phoebe Zipper Sweatshirt',
     price: 'As low as $59.00',
     sizes: Sizes,
-    colors: [Colors.Grey, Colors.Purple, Colors.White],
+    colors: [Colors.Gray, Colors.Purple, Colors.White],
     link: '/phoebe-zipper-sweatshirt.html',
   },
   Daphne: {

--- a/tests/data/productCategories/womenJackets.ts
+++ b/tests/data/productCategories/womenJackets.ts
@@ -238,7 +238,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $32.00',
     sizes: Sizes,
-    colors: [Colors.Blue, Colors.Grey, Colors.Green],
+    colors: [Colors.Blue, Colors.Gray, Colors.Green],
     link: '/jade-yoga-jacket.html',
   },
   Adrienne: {
@@ -247,7 +247,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '2 Reviews',
     price: 'As low as $57.00',
     sizes: Sizes,
-    colors: [Colors.Grey, Colors.Orange, Colors.Purple],
+    colors: [Colors.Gray, Colors.Orange, Colors.Purple],
     link: '/adrienne-trek-jacket.html',
   },
   Inez: {
@@ -292,7 +292,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '4 Reviews',
     price: 'As low as $56.25',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Blue, Colors.Grey],
+    colors: [Colors.Black, Colors.Blue, Colors.Gray],
     link: '/josie-yoga-jacket.html',
   },
   Stellar: {

--- a/tests/data/productCategories/womenPants.ts
+++ b/tests/data/productCategories/womenPants.ts
@@ -181,7 +181,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Deirdre Relaxed-Fit Capri',
     price: 'As low as $50.40',
     sizes: Sizes,
-    colors: [Colors.Blue, Colors.Grey, Colors.Green],
+    colors: [Colors.Blue, Colors.Gray, Colors.Green],
     link: '/deirdre-relaxed-fit-capri.html',
   },
   Sylvia: {
@@ -195,7 +195,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Daria Bikram Pant',
     price: 'As low as $40.80',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Grey, Colors.White],
+    colors: [Colors.Black, Colors.Gray, Colors.White],
     link: '/daria-bikram-pant.html',
   },
   Carina: {
@@ -234,7 +234,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '2 Reviews',
     price: 'As low as $60.00',
     sizes: Sizes,
-    colors: [Colors.Blue, Colors.Grey, Colors.Red],
+    colors: [Colors.Blue, Colors.Gray, Colors.Red],
     link: '/sahara-leggings.html',
   },
   Cora: {
@@ -270,7 +270,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '2 Reviews',
     price: 'As low as $31.20',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Grey, Colors.White],
+    colors: [Colors.Black, Colors.Gray, Colors.White],
     link: '/karmen-yoga-pant.html',
   },
 };

--- a/tests/data/productCategories/womenShorts.ts
+++ b/tests/data/productCategories/womenShorts.ts
@@ -201,7 +201,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $44.00',
     sizes: Sizes.Small,
-    colors: [Colors.Grey, Colors.Green, Colors.White],
+    colors: [Colors.Gray, Colors.Green, Colors.White],
     link: '/mimi-all-purpose-short.html',
   },
   Sybil: {
@@ -228,7 +228,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '2 Reviews',
     price: 'As low as $42.00',
     sizes: Sizes.Small,
-    colors: [Colors.Grey, Colors.Orange, Colors.Purple],
+    colors: [Colors.Gray, Colors.Orange, Colors.Purple],
     link: '/angel-light-running-short.html',
   },
   Bess: {
@@ -255,7 +255,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '2 Reviews',
     price: 'As low as $50.00',
     sizes: Sizes.All,
-    colors: [Colors.Blue, Colors.Grey, Colors.Orange],
+    colors: [Colors.Blue, Colors.Gray, Colors.Orange],
     link: '/gwen-drawstring-bike-short.html',
   },
   Maxima: {
@@ -264,7 +264,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '3 Reviews',
     price: 'As low as $28.00',
     sizes: Sizes.All,
-    colors: [Colors.Grey, Colors.Orange, Colors.Yellow],
+    colors: [Colors.Gray, Colors.Orange, Colors.Yellow],
     link: '/maxima-drawstring-short.html',
   },
   Fiona: {

--- a/tests/data/productCategories/womenTanks.ts
+++ b/tests/data/productCategories/womenTanks.ts
@@ -289,7 +289,7 @@ export const ProductDetails: Record<string, Product> = {
     reviews: '4 Reviews',
     price: 'As low as $39.00',
     sizes: Sizes,
-    colors: [Colors.Black, Colors.Grey, Colors.Purple],
+    colors: [Colors.Black, Colors.Gray, Colors.Purple],
     link: '/electra-bra-top.html',
   },
 };

--- a/tests/data/productCategories/womenTanks.ts
+++ b/tests/data/productCategories/womenTanks.ts
@@ -150,14 +150,36 @@ export const ProductDetails: Record<string, Product> = {
     rating: '70%',
     reviews: '2 Reviews',
     price: 'As low as $34.00',
+    inStock: true,
+    sku: 'WT09',
     sizes: Sizes,
     colors: [Colors.Purple, Colors.White, Colors.Yellow],
     link: '/breathe-easy-tank.html',
     images: {
       default: '/w/t/wt09-white_main_1.jpg',
+      thumbnails: ['/w/t/wt09-white_main_1.jpg', '/w/t/wt09-white_back_1.jpg'],
       colors: ['/w/t/wt09-purple_main_1.jpg', '/w/t/wt09-white_main_1.jpg', '/w/t/wt09-yellow_main_1.jpg'],
       sizes: '/w/t/wt09-purple_main_1.jpg',
     },
+    description:
+      "The Breathe Easy Tank is so soft, lightweight, and comfortable, you won't even know it's there -- until its high-tech Cocona® fabric starts wicking sweat away from your body to help you stay dry and focused. Layer it over your favorite sports bra and get moving.\n\n• Machine wash/dry.\n• Cocona® fabric.",
+    additionalInfo: 'Style\tTank\nMaterial\tCocona® performance fabric, Cotton\nPattern\tSolid\nClimate\tIndoor, Warm',
+    reviewDetails: [
+      {
+        title: 'Great fit - love the v-neck design!',
+        rating: '80%',
+        reviewText: 'Great fit - love the v-neck design!',
+        reviewer: 'Thalia',
+        date: '3/11/23',
+      },
+      {
+        title: 'The seams bother me',
+        rating: '60%',
+        reviewText: 'Some of the seams bother me during certain workouts but otherwise very comfortable',
+        reviewer: 'Carma',
+        date: '3/11/23',
+      },
+    ],
   },
   Antonia: {
     name: 'Antonia Racer Tank',

--- a/tests/data/productCategories/womenTees.ts
+++ b/tests/data/productCategories/womenTees.ts
@@ -243,7 +243,7 @@ export const ProductDetails: Record<string, Product> = {
     name: 'Elisa EverCool™ Tee',
     price: 'As low as $29.00',
     sizes: Sizes,
-    colors: [Colors.Grey, Colors.Purple, Colors.Red],
+    colors: [Colors.Gray, Colors.Purple, Colors.Red],
     link: '/elisa-evercool-trade-tee.html',
   },
   Layla: {

--- a/tests/data/productPage.ts
+++ b/tests/data/productPage.ts
@@ -1,3 +1,5 @@
+import { ProductDetails as WomenShorts } from './productCategories/womenShorts';
+import { ProductDetails as WomenTanks } from './productCategories/womenTanks';
 import { ProductDetails as WomenTees } from './productCategories/womenTees';
 import { Product } from './products';
 
@@ -11,6 +13,7 @@ export const ExpectedText = {
 
 export const Products: Record<string, Product> = {
   RadiantTee: WomenTees.Radiant,
+  BreatheEasyTank: WomenTanks.BreatheEasy,
 };
 
 export const SimilarProducts: Record<string, Product[]> = {
@@ -27,4 +30,5 @@ export const SimilarProducts: Record<string, Product[]> = {
     WomenTees.Karissa,
     WomenTees.Diva,
   ],
+  BreatheEasyTank: [WomenShorts.Mimi, WomenTees.Gabrielle, WomenShorts.Ana, WomenTees.Juliana],
 };

--- a/tests/data/productPage.ts
+++ b/tests/data/productPage.ts
@@ -9,6 +9,8 @@ import { ProductDetails as WomenTees } from './productCategories/womenTees';
 import { Product } from './products';
 
 export const ExpectedText = {
+  AddReview: 'Add Your Review',
+  NoReviews: 'Be the first to review this product',
   Quantity: {
     BelowMin: 'Please enter a quantity greater than 0.',
     AboveMax: 'The maximum you may purchase is 10000.',

--- a/tests/data/productPage.ts
+++ b/tests/data/productPage.ts
@@ -1,3 +1,4 @@
+import { ProductDetails as GearBags } from './productCategories/gearBags';
 import { ProductDetails as MenHoodies } from './productCategories/menHoodies';
 import { ProductDetails as MenPants } from './productCategories/menPants';
 import { ProductDetails as MenShorts } from './productCategories/menShorts';
@@ -23,6 +24,7 @@ export const Products: Record<string, Product> = {
   BreatheEasyTank: WomenTanks.BreatheEasy,
   ArgusTank: MenTanks.Argus,
   HeroHoodie: MenHoodies.Hero,
+  FusionBag: GearBags.Fusion,
 };
 
 export const SimilarProducts: Record<string, Product[]> = {
@@ -42,4 +44,5 @@ export const SimilarProducts: Record<string, Product[]> = {
   BreatheEasyTank: [WomenShorts.Mimi, WomenTees.Gabrielle, WomenShorts.Ana, WomenTees.Juliana],
   ArgusTank: [MenShorts.Apollo, MenShorts.Pierce, MenTees.AtomicCrew, MenTees.Gobi],
   HeroHoodie: [MenPants.Viktor, MenPants.Livingston, MenTees.Aero, MenTees.Strike],
+  FusionBag: [GearBags.Impulse],
 };

--- a/tests/data/productPage.ts
+++ b/tests/data/productPage.ts
@@ -1,3 +1,5 @@
+import { ProductDetails as MenHoodies } from './productCategories/menHoodies';
+import { ProductDetails as MenPants } from './productCategories/menPants';
 import { ProductDetails as MenShorts } from './productCategories/menShorts';
 import { ProductDetails as MenTanks } from './productCategories/menTanks';
 import { ProductDetails as MenTees } from './productCategories/menTees';
@@ -18,6 +20,7 @@ export const Products: Record<string, Product> = {
   RadiantTee: WomenTees.Radiant,
   BreatheEasyTank: WomenTanks.BreatheEasy,
   ArgusTank: MenTanks.Argus,
+  HeroHoodie: MenHoodies.Hero,
 };
 
 export const SimilarProducts: Record<string, Product[]> = {
@@ -36,4 +39,5 @@ export const SimilarProducts: Record<string, Product[]> = {
   ],
   BreatheEasyTank: [WomenShorts.Mimi, WomenTees.Gabrielle, WomenShorts.Ana, WomenTees.Juliana],
   ArgusTank: [MenShorts.Apollo, MenShorts.Pierce, MenTees.AtomicCrew, MenTees.Gobi],
+  HeroHoodie: [MenPants.Viktor, MenPants.Livingston, MenTees.Aero, MenTees.Strike],
 };

--- a/tests/data/productPage.ts
+++ b/tests/data/productPage.ts
@@ -25,6 +25,7 @@ export const Products: Record<string, Product> = {
   ArgusTank: MenTanks.Argus,
   HeroHoodie: MenHoodies.Hero,
   FusionBag: GearBags.Fusion,
+  PushItBag: GearBags.PushIt,
 };
 
 export const SimilarProducts: Record<string, Product[]> = {
@@ -45,4 +46,5 @@ export const SimilarProducts: Record<string, Product[]> = {
   ArgusTank: [MenShorts.Apollo, MenShorts.Pierce, MenTees.AtomicCrew, MenTees.Gobi],
   HeroHoodie: [MenPants.Viktor, MenPants.Livingston, MenTees.Aero, MenTees.Strike],
   FusionBag: [GearBags.Impulse],
+  PushItBag: [GearBags.Fusion, GearBags.Impulse],
 };

--- a/tests/data/productPage.ts
+++ b/tests/data/productPage.ts
@@ -1,3 +1,6 @@
+import { ProductDetails as MenShorts } from './productCategories/menShorts';
+import { ProductDetails as MenTanks } from './productCategories/menTanks';
+import { ProductDetails as MenTees } from './productCategories/menTees';
 import { ProductDetails as WomenShorts } from './productCategories/womenShorts';
 import { ProductDetails as WomenTanks } from './productCategories/womenTanks';
 import { ProductDetails as WomenTees } from './productCategories/womenTees';
@@ -14,6 +17,7 @@ export const ExpectedText = {
 export const Products: Record<string, Product> = {
   RadiantTee: WomenTees.Radiant,
   BreatheEasyTank: WomenTanks.BreatheEasy,
+  ArgusTank: MenTanks.Argus,
 };
 
 export const SimilarProducts: Record<string, Product[]> = {
@@ -31,4 +35,5 @@ export const SimilarProducts: Record<string, Product[]> = {
     WomenTees.Diva,
   ],
   BreatheEasyTank: [WomenShorts.Mimi, WomenTees.Gabrielle, WomenShorts.Ana, WomenTees.Juliana],
+  ArgusTank: [MenShorts.Apollo, MenShorts.Pierce, MenTees.AtomicCrew, MenTees.Gobi],
 };

--- a/tests/data/products.ts
+++ b/tests/data/products.ts
@@ -6,7 +6,7 @@ export const Colors = {
   Brown: 'rgb(148, 84, 84)',
   DarkGrey: 'rgb(51, 51, 51)',
   Green: 'rgb(83, 168, 40)',
-  Grey: 'rgb(143, 143, 143)',
+  Gray: 'rgb(143, 143, 143)',
   Lavender: 'rgb(206, 100, 212)',
   LightGrey: 'rgb(240, 240, 240)',
   Orange: 'rgb(235, 103, 3)',

--- a/tests/pages/productPage.ts
+++ b/tests/pages/productPage.ts
@@ -133,6 +133,11 @@ export class ProductPage extends BasePage {
     await this.zoomOutButton.click();
     await sleep(500);
   }
+
+  async dblClickImage() {
+    await this.productImage.dblclick();
+    await sleep(1000);
+  }
 }
 
 async function sleep(ms: number) {

--- a/tests/pages/productPage.ts
+++ b/tests/pages/productPage.ts
@@ -111,28 +111,32 @@ export class ProductPage extends BasePage {
   async selectThumbnail(index: number) {
     await this.productThumbnail.nth(index).click();
     // Without this sleep the highlight border may not be in the right place
-    await new Promise((r) => setTimeout(r, 1000));
+    await sleep(1000);
   }
 
   async selectNextImage() {
     await this.nextImageButton.click();
-    await new Promise((r) => setTimeout(r, 1000));
+    await sleep(1000);
   }
 
   async selectPreviousImage() {
     await this.prevImageButton.click();
-    await new Promise((r) => setTimeout(r, 1000));
+    await sleep(1000);
   }
 
   async zoomIn() {
     await this.zoomInButton.click();
-    await new Promise((r) => setTimeout(r, 500));
+    await sleep(500);
   }
 
   async zoomOut() {
     await this.zoomOutButton.click();
-    await new Promise((r) => setTimeout(r, 500));
+    await sleep(500);
   }
+}
+
+async function sleep(ms: number) {
+  await new Promise((r) => setTimeout(r, ms));
 }
 
 export enum ReviewDetails {

--- a/tests/pages/productPage.ts
+++ b/tests/pages/productPage.ts
@@ -92,7 +92,7 @@ export class ProductPage extends BasePage {
     this.description = this.secondaryInfo.locator('#description');
     this.additionalInfo = this.secondaryInfo.locator('#additional tbody');
     this.review = this.secondaryInfo.locator('#customer-reviews li.review-item');
-    this.similarProductsGrid = this.mainContent.locator('.block.upsell .products-grid');
+    this.similarProductsGrid = this.mainContent.locator('.block .products-grid');
     this.similarProductItem = new ProductItem(this.similarProductsGrid).product;
   }
 

--- a/tests/specs/productPage.spec.ts
+++ b/tests/specs/productPage.spec.ts
@@ -277,7 +277,8 @@ for (const product of products) {
     });
 
     test.describe('Product image carousel tests', () => {
-      test('First thumbnail selected by default', async () => {
+      test('First thumbnail selected by default', async ({}, testInfo) => {
+        testInfo.skip(!Products[product].images!.thumbnails, 'Product has no thumbnails so skip test');
         const thumbnailSrc = await productPage.productThumbnail.first().getAttribute('src');
         const mainImageSrc = await productPage.productImage.getAttribute('src');
         verifyImageSrcEquality(mainImageSrc!, thumbnailSrc!);
@@ -290,7 +291,8 @@ for (const product of products) {
           .toEqual(await productPage.productThumbnail.nth(0).boundingBox());
       });
 
-      test('Product image changes when thumbnail selected', async () => {
+      test('Product image changes when thumbnail selected', async ({}, testInfo) => {
+        testInfo.skip(!Products[product].images!.thumbnails, 'Product has no thumbnails so skip test');
         await expect.soft(productPage.productThumbnail).toHaveCount(Products[product].images!.thumbnails.length);
         for (let i = 1; i < (await productPage.productThumbnail.count()); i++) {
           await productPage.selectThumbnail(i);
@@ -312,7 +314,8 @@ for (const product of products) {
           .toEqual(await productPage.productThumbnail.nth(0).boundingBox());
       });
 
-      test('Previous/next image buttons cycle through product images', async () => {
+      test('Previous/next image buttons cycle through product images', async ({}, testInfo) => {
+        testInfo.skip(!Products[product].images!.thumbnails, 'Product has no thumbnails so skip test');
         await expect.soft(productPage.productThumbnail).toHaveCount(Products[product].images!.thumbnails.length);
         for (let i = 0; i < (await productPage.productThumbnail.count()) - 1; i++) {
           await productPage.selectNextImage();
@@ -409,11 +412,13 @@ for (const product of products) {
         await expect
           .soft(productPage.productImage)
           .toHaveAttribute('src', new RegExp(mediaDir + Products[product].images!.default));
-        await expect.soft(productPage.productThumbnail).toHaveCount(Products[product].images!.thumbnails.length);
-        for (let i = 0; i < Products[product].images!.thumbnails.length; i++) {
-          await expect
-            .soft(productPage.productThumbnail.nth(i))
-            .toHaveAttribute('src', new RegExp(mediaDir + Products[product].images!.thumbnails[i]));
+        if (Products[product].images!.thumbnails) {
+          await expect.soft(productPage.productThumbnail).toHaveCount(Products[product].images!.thumbnails.length);
+          for (let i = 0; i < Products[product].images!.thumbnails.length; i++) {
+            await expect
+              .soft(productPage.productThumbnail.nth(i))
+              .toHaveAttribute('src', new RegExp(mediaDir + Products[product].images!.thumbnails[i]));
+          }
         }
         if (Products[product].images!.sizes) {
           for (let i = 0; i < Products[product].sizes!.length; i++) {

--- a/tests/specs/productPage.spec.ts
+++ b/tests/specs/productPage.spec.ts
@@ -370,39 +370,42 @@ for (const product of products) {
         await productPage.zoomOut();
         verifyBoundingBoxEquality(await productPage.productImage.boundingBox(), origBox);
 
-        // Can zoom in 6 times max
-        for (let i = 0; i <= maxZooms; i++) {
-          const box = await productPage.productImage.boundingBox();
+        let box: BoundingBox;
+        let currentBox: BoundingBox;
+        // Zoom in until the size no longer changes
+        do {
+          box = await productPage.productImage.boundingBox();
           await productPage.zoomIn();
-          if (i < maxZooms) {
-            expect.soft((await productPage.productImage.boundingBox())!.width).toBeGreaterThan(box!.width);
-            expect.soft((await productPage.productImage.boundingBox())!.height).toBeGreaterThan(box!.height);
+          currentBox = await productPage.productImage.boundingBox();
+          if (currentBox!.width !== box!.width || currentBox!.height !== box!.height) {
+            expect.soft(currentBox!.width).toBeGreaterThan(box!.width);
+            expect.soft(currentBox!.height).toBeGreaterThan(box!.height);
           } else {
-            verifyBoundingBoxEquality(await productPage.productImage.boundingBox(), box);
+            verifyBoundingBoxEquality(currentBox, box);
           }
-        }
+        } while (currentBox!.width !== box!.width || currentBox!.height !== box!.height);
         const maxBox = await productPage.productImage.boundingBox();
-        // Can zoom out 5 times max. Why it's not 6 as for zooming in I have no idea!
-        for (let i = 0; i < maxZooms; i++) {
-          const box = await productPage.productImage.boundingBox();
+        // Zoom out until the size no longer changes
+        do {
+          box = await productPage.productImage.boundingBox();
           await productPage.zoomOut();
-          if (i < maxZooms - 1) {
-            expect.soft((await productPage.productImage.boundingBox())!.width).toBeLessThan(box!.width);
-            expect.soft((await productPage.productImage.boundingBox())!.height).toBeLessThan(box!.height);
+          currentBox = await productPage.productImage.boundingBox();
+          if (currentBox!.width !== box!.width || currentBox!.height !== box!.height) {
+            expect.soft(currentBox!.width).toBeLessThan(box!.width);
+            expect.soft(currentBox!.height).toBeLessThan(box!.height);
           } else {
-            verifyBoundingBoxEquality(await productPage.productImage.boundingBox(), box);
+            verifyBoundingBoxEquality(currentBox, box);
           }
-        }
+        } while (currentBox!.width !== box!.width || currentBox!.height !== box!.height);
+
         // Zoom level is returned to the original setting
         verifyBoundingBoxEquality(await productPage.productImage.boundingBox(), origBox);
 
         // Double-clicking product image zooms in to the max
-        await productPage.productImage.dblclick();
-        await new Promise((r) => setTimeout(r, 1000));
+        await productPage.dblClickImage();
         verifyBoundingBoxEquality(await productPage.productImage.boundingBox(), maxBox!);
         // Double-clicking again returns to the original zoom level
-        await productPage.productImage.dblclick();
-        await new Promise((r) => setTimeout(r, 1000));
+        await productPage.dblClickImage();
         verifyBoundingBoxEquality(await productPage.productImage.boundingBox(), origBox);
       });
 

--- a/tests/specs/productPage.spec.ts
+++ b/tests/specs/productPage.spec.ts
@@ -25,7 +25,7 @@ function verifyBoundingBoxEquality(actualBox: BoundingBox, expectedBox: Bounding
 }
 
 dotenv.config();
-const products = process.env.TEST_MODE === 'full' ? Object.keys(Products) : ['RadiantTee'];
+const products = process.env.TEST_MODE === 'full' ? Object.keys(Products) : ['BreatheEasyTank'];
 for (const product of products) {
   test.describe(`${product} page tests`, () => {
     let productPage: ProductPage;

--- a/tests/specs/productPage.spec.ts
+++ b/tests/specs/productPage.spec.ts
@@ -25,7 +25,7 @@ function verifyBoundingBoxEquality(actualBox: BoundingBox, expectedBox: Bounding
 }
 
 dotenv.config();
-const products = process.env.TEST_MODE === 'full' ? Object.keys(Products) : ['BreatheEasyTank'];
+const products = process.env.TEST_MODE === 'full' ? Object.keys(Products) : ['RadiantTee'];
 for (const product of products) {
   test.describe(`${product} page tests`, () => {
     let productPage: ProductPage;
@@ -56,21 +56,21 @@ for (const product of products) {
         await expect.soft(productPage.pageFooter.copyrightFooter).toBeVisible();
       });
 
-      test('Product details', async ({ baseURL }) => {
+      test('Product details', async () => {
         // The breadcrumbs will vary depending on the route taken to the page but by navigating to the product page
         // directly the breadcrumbs will always be Home > {Product Name}
         const breadcrumbsExpectedText = `Home  ${Products[product].name}`;
         await expect.soft(productPage.breadcrumbsContainer).toHaveText(breadcrumbsExpectedText);
 
         await expect.soft(productPage.productName).toHaveText(Products[product].name);
-        if (Products[product].reviews) {
-          await expect.soft(productPage.reviews).toHaveText(Products[product].reviews!);
-        }
         if (Products[product].rating) {
           await expect.soft(productPage.rating).toHaveAttribute('title', Products[product].rating!);
         }
         if (Products[product].reviewDetails) {
           await expect.soft(productPage.reviews).toHaveText(`${Products[product].reviewDetails!.length} Reviews`);
+          await expect.soft(productPage.addReview).toHaveText(ExpectedText.AddReview);
+        } else {
+          await expect.soft(productPage.addReview).toHaveText(ExpectedText.NoReviews);
         }
         await expect.soft(productPage.price).toHaveText(Products[product].price);
         const availability = Products[product].inStock ? 'In stock' : 'Out of stock';

--- a/tests/specs/productPage.spec.ts
+++ b/tests/specs/productPage.spec.ts
@@ -133,7 +133,7 @@ for (const product of products) {
               .toHaveText(SimilarProducts[product][i].name);
             await expect
               .soft(productPage.getSimilarProductItemElement(i, ProductItemElements.Price).first())
-              .toHaveText(SimilarProducts[product][i].price);
+              .toHaveText(SimilarProducts[product][i].price, { useInnerText: true });
           }
         }
       });


### PR DESCRIPTION
This PR extends the existing product page tests that originally only covered the Radiant Tee product to cover all products featured on the home page, namely:
- Breathe Easy Tank
- Argus Tank
- Hero Hoodie
- Fusion Bag
- Push It Bag

These additional products identified a few issues with the existing product page tests that needed to be addressed. This is not surprising given the tests were written around a single product. The changes include:
- updating some color key spellings to US English
- verifying the correct text is displayed in the product info if the product has no reviews
- skipping certain tests/assertions for products without thumbnails
- replacing the for loops with do-while loops in the image carousel zoom test due to variations in the max number of zoom levels

With this PR the tests now cover 6 (out of 181) products. Despite only representing a tiny fraction of the total product range these products cover the major options for the full catalog (some have reviews, some don't; some have multiple thumbnails, some don't; some have different size/color options, some don't etc) so I am pretty confident that the product page tests provide good coverage of the overall functionality, at least as far as currently intended. There is still further functionality I want to add tests for at some stage but now the tests can be run for multiple products it will make it easier to ensure future tests are robust and work for different products