### PR TITLE
Handle Google AdSense

### DIFF
--- a/tests/specs/collectionPage.spec.ts
+++ b/tests/specs/collectionPage.spec.ts
@@ -4,7 +4,6 @@ import { Collections, ExpectedText, Links, Filters, Products, ShoppingOptions } 
 import { ProductItemElements } from '../pages/components/productItem';
 import { Colors, Links as HeaderLinks, TopnavLvl0 } from '../data/pageHeader';
 import * as dotenv from 'dotenv';
-import path from 'path';
 
 const Timeouts = {
   Visual: 20000,
@@ -86,9 +85,13 @@ for (const collection of pages) {
         const promoBlocks = collectionPage.promoBlock;
         await expect.soft(promoBlocks).toHaveCount(collectionExpectedText.PromoBlocks.length);
         for (let i = 0; i < collectionExpectedText.PromoBlocks.length; i++) {
-          await expect
-            .soft(promoBlocks.nth(i))
-            .toHaveText(collectionExpectedText.PromoBlocks[i], { useInnerText: true });
+          // Handle Google AdSense by splitting actual & expected text into separate lines and
+          // verifying that all expected lines appear in actual text
+          const actualText = (await promoBlocks.nth(i).textContent())!.split('\n');
+          const expectedText = collectionExpectedText.PromoBlocks[i].split('\n');
+          for (let expectedLine of expectedText) {
+            expect.soft(actualText.includes(expectedLine));
+          }
         }
         if (
           collectionExpectedText.ProductsGrid.hasOwnProperty('Title') &&

--- a/tests/specs/productCategoryPage.spec.ts
+++ b/tests/specs/productCategoryPage.spec.ts
@@ -334,7 +334,9 @@ for (const lvl0Category of getProductCategories(mode, 0)) {
 
           // Filters split into separate test to avoid making the above test really hard to read (& develop)
           test('Text content of filters', async () => {
-            await expect.soft(productCategoryPage.filtersTitle).toHaveText(ExpectedText.FiltersTitle);
+            // Verify filters title starts with expected text rather than a full match as a way of handling Google AdSense
+            const actualText = await productCategoryPage.filtersTitle.textContent();
+            expect.soft(actualText?.trim().startsWith(ExpectedText.FiltersTitle)).toBeTruthy;
             const filterCategories = productCategoryPage.filterCategory;
             const expectedFilters = Filters[category];
             await expect.soft(filterCategories).toHaveCount(expectedFilters.length);


### PR DESCRIPTION
I was hoping to be able to put this project to bed and not have to actively maintain it but it seems Google AdSense has other ideas as it keeps interfering with my tests and causing them to fail. I want to maintain a green pipeline, obviously, so I am fixing the tests as issues come to light.

In this instance I have made slight changes to the collection and product category page tests to allow for Google AdSense appearing in places where I verify the text content. Rather than using the native `toHaveText` assertions I have had to break the text up and check each expected line occurs (for the collection tests) or verify the actual text starts with the expected value (for the product category tests). Hopefully this is enough to green up the pipeline once more.